### PR TITLE
Started implementing adaptive target resolution

### DIFF
--- a/Rules/Velociraptor-Rules.yaml
+++ b/Rules/Velociraptor-Rules.yaml
@@ -16,7 +16,7 @@ Preamble:
       WHERE Name =~ Regex
     })
 
-  # Convert from a numeric protocl id to a name.
+  # Convert from a numeric protocol id to a name.
   - |
     LET _ProtocolLookup <= dict(`6`="TCP", `17`="UDP")
     LET ProtocolLookup(X) = get(item=_ProtocolLookup, field=X) || X
@@ -58,6 +58,15 @@ Preamble:
        SELECT * FROM items(item=D)
        WHERE _value
     })
+
+  # Try to parse the path into something resembling the binary.
+  # Sometimes we see things like "\SystemRoot\System32\..." which
+  # should be expanded into "%SystemRoot%\System32"
+  - LET ExpandPath(Path) = commandline_split(
+    command=expand(path=regex_transform(source=Path,
+      map=dict(
+        `^\\\\SystemRoot\\\\`="%SystemRoot%\\"
+      ))))[0]
 
 Rules:
 - Description: Interface Properties (IPv4)
@@ -145,7 +154,11 @@ Rules:
        WHERE NOT _key =~ "^v"
     })
 
-    LET ParseFirewallRule(X) = _ParseFirewallRule(X=X) +
+    LET MaybeEnrichFirewallRule(OSPath, Details) = if(condition=Details.App,
+    then=Details + GetDetails(OSPath=ExpandPath(Path=Details.App)), else=Details)
+
+    LET ParseFirewallRule(X) = MaybeEnrichFirewallRule(
+       OSPath=OSPath, Details=_ParseFirewallRule(X=X)) +
        dict(Protocol=ProtocolLookup(X=_ParseFirewallRule(X=X).Protocol))
 
   Details: |
@@ -459,8 +472,16 @@ Rules:
   Root: HKEY_LOCAL_MACHINE\Software
   Glob: 'Microsoft\Windows\CurrentVersion\Run*'
   Filter: x=>IsDir AND Details
+  Preamble:
+  - LET EnumerateRunKey(OSPath) = SELECT Name,
+        Data.value AS RawTarget,
+        ExpandPath(Path=Data.value) AS CommandImage,
+        GetDetails(OSPath=ExpandPath(Path=Data.value)) AS Details
+    FROM glob(accessor="registry", globs="*", root=OSPath)
+    WHERE NOT IsDir
+
   Details: |
-    x=>FetchKeyValues(OSPath=x.OSPath)
+    x=>EnumerateRunKey(OSPath=x.OSPath)
 
 - Author: Andrew Rathbun, Mike Cohen
   Description: Scheduled Tasks (TaskCache)
@@ -559,12 +580,18 @@ Rules:
       LET _ServiceTypeLookup <= dict(`1`="KernelDriver", `2`="FileSystemDriver", `4`="Adapter", `8`="RecognizerDriver", `16`="Win32OwnProcess", `32`="Win32ShareProcess", `256`="InteractiveProcess", `96`="Win32ShareProcess")
       LET _ServiceStartModeLookup <= dict(`0`="Boot", `1`="System", `2`="Automatic", `3`="Manual", `4`="Disabled")
 
-      LET _ServicesInfo(OSPath) =
-          FetchKeyValuesWithRegex(OSPath=OSPath, Regex="Description|DisplayName|ServiceDll|Group|ImagePath|RequiredPrivileges|Type|Parameters|SERVICEDLL") +
+      LET MaybeEnrichService(OSPath, Details) = if(condition=Details.ImagePath,
+       then=Details + GetDetails(OSPath=ExpandPath(Path=Details.ImagePath)),
+       else=Details)
+
+      LET _ServicesInfo(OSPath) = MaybeEnrichService(OSPath=OSPath, Details=
+          FetchKeyValuesWithRegex(OSPath=OSPath,
+               Regex="Description|DisplayName|ServiceDll|Group|ImagePath|RequiredPrivileges|Type|Parameters|SERVICEDLL") +
           dict(Mtime=Mtime, Service=OSPath.Basename,
                TypeName=get(item=_ServiceTypeLookup, field=str(str=GetValue(OSPath=OSPath + "Type"))),
                StartName=get(item=_ServiceStartModeLookup, field=str(str=GetValue(OSPath=OSPath + "Start")))
-          )
+          ))
+
   Details: |
     x=>_ServicesInfo(OSPath=x.OSPath)
 

--- a/compiler/index.go
+++ b/compiler/index.go
@@ -12,7 +12,7 @@ func (self *Compiler) WriteIndex(path string) error {
 		return err
 	}
 
-	serialized, _ := json.Marshal(self.rules)
+	serialized, _ := json.MarshalIndent(self.rules, " ", " ")
 	out_fd.Write(serialized)
 	return out_fd.Close()
 }

--- a/compiler/template.yaml
+++ b/compiler/template.yaml
@@ -30,7 +30,7 @@ description: |
       except for all the raw user hives will be mapped in HKEY_USERS.
       Therefore all users will be visible.
    3. Raw Hives - This stragegy is most suitable for working off an image or
-       acquired hive files. All raw hives will be mapped (include SYSTEM, SOFTWARE etc).
+      acquired hive files. All raw hives will be mapped (include SYSTEM, SOFTWARE etc).
 
    Using the API will result in faster collection times, but may be some
    differences:
@@ -42,6 +42,16 @@ description: |
    * Some hive files are not accessible and can only be accessible using the
      API (e.g. the BCD hives).
 
+   ## CollectionPolicy
+
+   Some rules attempt to resolve links to other files on the disk. For
+   example, category `Autoruns` may attempt to resolve the actual
+   binaries being launched. These targets may be collected according
+   to the `CollectionPolicy`. By default targets are not
+   resolved. However, you may specify that unsigned binaries be
+   collected (uploaded to the server), or other files (e.g. a `lnk`
+   file).
+
 parameters:
 - name: Categories
   type: multichoice
@@ -51,19 +61,21 @@ parameters:
    {{- range $val := .Categories }}
     - "{{ $val }}"
    {{- end }}
-- name: CategoryFilter
-  description: If this is set we use the regular expression instead of the choices above.
-  type: regex
-- name: CategoryExcludedFilter
-  description: Exclude any categories based on this regular expression
-  type: regex
-  default: XXXXXX
-- name: DescriptionFilter
+- name: RuleFilter
   type: regex
   default: .
-- name: RootFilter
-  type: regex
-  default: .
+
+- name: CollectionPolicy
+  description: |
+    Extract targets will be collected using this policy.
+  type: choices
+  choices:
+    - ExcludeSigned
+    - HashOnly
+    - AllFiles
+    - None
+  default: HashOnly
+
 - name: RemappingStrategy
   description: |
      In order to present a unified view of all registry hives we remap various hives
@@ -87,46 +99,100 @@ parameters:
   type: bool
   description: If checked, we also upload all the hives.
 
-- name: PathTOSAM
-  description: "By default, hive is at C:/Windows/System32/Config/SAM"
-
-- name: PathTOAmcache
-  description: "By default, hive is at C:/Windows/appcompat/Programs/Amcache.hve"
-
-- name: PathTOSecurity
-  description: "By default, hive is at C:/Windows/System32/Config/SECURITY"
-
-- name: PathTOSystem
-  description: "By default, hive is at C:/Windows/System32/Config/SYSTEM"
-
-- name: PathTOSoftware
-  description: "By default, hive is at C:/Windows/System32/Config/SOFTWARE"
-
-- name: PathTOUsers
-  description: "By default, directory is at C:/Users"
-
-- name: NTFS_CACHE_TIME
-  type: int
-  description: How often to flush the NTFS cache. (Default is never).
-  default: "1000000"
-
 - name: DEBUG
   type: bool
   description: Add more logging.
 
+implied_permissions:
+- IMPERSONATION
+
 export: |
     LET _info <= SELECT * FROM info()
+    LET S = scope()
+    LET RootFilter <= S.RootFilter || "."
+    LET NTFS_CACHE_TIME <= S.NTFS_CACHE_TIME || 1000000
+    LET CollectionPolicy <= S.CollectionPolicy || "ExcludeSigned"
+
+    LET CollectionPolicy <= if(condition=RemappingStrategy =~ "API",
+      then= CollectionPolicy,
+      else=log(message="CollectionPolicy set to None as RemappingStrategy strategy is not API based") && "None")
+
+    LET MaxFileSize <= S.MaxFileSize || 0
+    LET MaxHashSize <= S.MaxHashSize || 100000000
+
+    // In ExcludeSigned and HashOnly we dont upload signed binaries.
+    LET ShouldUploadSignedBinary <= dict(
+       ShouldUpload = NOT CollectionPolicy =~ "ExcludeSigned|HashOnly")
+
+    // In HashOnly mode we never upload anything.
+    LET ShouldUploadAnyFile <= dict(
+       ShouldUpload = NOT CollectionPolicy =~ "HashOnly|None")
+
+    LET DoNotUpload <= dict(ShouldUpload=FALSE)
+
+    // Determine if we should upload the file based on signature.
+    LET ShouldUpload(Details) = if(
+      condition=MaxFileSize > 0 AND Details.Stat.Size > MaxFileSize,
+      then= Details + DoNotUpload,
+      else=if(
+       // What to do about binaries? If they have an issuer name then
+       // they are signed.
+       condition=Details.Signatures.IssuerName,
+       then=Details + ShouldUploadSignedBinary,
+       else=Details + ShouldUploadAnyFile))
+
+    // If the file is a binary, also add authenticode information.
+    LET MaybeBinary(OSPath, Details) = ShouldUpload(Details=if(
+       condition=Details.Magic =~ "PE.+executable",
+       then=Details + dict(Signatures=authenticode(filename=OSPath)),
+       else=Details))
+
+    // Hash the file if it is not too large
+    LET MaybeHash(OSPath) = if(
+      condition=stat(filename=OSPath).Size < MaxHashSize,
+      then=hash(path=OSPath),
+      else=log(message="Skipped hashing %v", args=OSPath, dedup=-1) && dict())
+
+    LET MaybeUpload(OSPath, Details) = if(condition=Details.ShouldUpload,
+      then=Details + dict(Upload=upload(file=OSPath)),
+      else=Details)
+
+    // Calculate the details column with hashes and magic.
+    LET _GetDetails(OSPath) = if(condition= CollectionPolicy =~ "None",
+    then=dict(),
+    else=MaybeUpload(OSPath=OSPath, Details=MaybeBinary(
+       OSPath=OSPath,
+       Details=dict(Hashes=MaybeHash(OSPath=OSPath),
+                    Stat=stat(filename=OSPath),
+                    Magic=magic(path=OSPath)))))
+
+    LET GetDetails(OSPath) = cache(
+       func= _GetDetails(OSPath=OSPath),
+       name="GetDetails", key=OSPath.String)
+
+    -- This contains the metadata for Glob rules.
+    LET _MD <= parse_json_array(data=gunzip(string=base64decode(string="{{.Metadata }}")))
+    LET MD(DescriptionFilter, RootFilter, CategoryFilter, CategoryExcludedFilter) =
+     SELECT Glob, Category, Description,
+            get(field="Details") AS Details,
+            get(field="Comment") AS Comment,
+            get(field="Filter") AS Filter, Root
+     FROM _MD
+     WHERE Description =~ DescriptionFilter
+       AND Root =~ RootFilter
+       AND Category =~ CategoryFilter
+       AND NOT Category =~ CategoryExcludedFilter
 
     -- On Non Windows systems we need to use case insensitive accessor or we might not find the right hives.
     LET DefaultAccessor <= if(condition=_info[0].OS =~ "windows", then="ntfs", else="file_nocase")
     LET HKLM <= pathspec(parse="HKEY_LOCAL_MACHINE", path_type="registry")
-    LET RootDrive <= pathspec(Path=RootDrive)
-    LET PathTOSAM <= PathTOSAM || RootDrive + "Windows/System32/config/SAM"
-    LET PathTOAmcache <= PathTOAmcache || RootDrive + "Windows/appcompat/Programs/Amcache.hve"
-    LET PathTOSystem <= PathTOSystem || RootDrive + "Windows/System32/Config/System"
-    LET PathTOSecurity <= PathTOSecurity || RootDrive + "Windows/System32/Config/Security"
-    LET PathTOSoftware <= PathTOSoftware || RootDrive + "Windows/System32/Config/Software"
-    LET PathTOUsers <= PathTOUsers || RootDrive + "Users/"
+    LET RootDrive <= pathspec(Path=S.RootDrive || "C:/")
+    LET PathTOSAM <= S.PathTOSAM || RootDrive + "Windows/System32/config/SAM"
+    LET PathTOAmcache <= S.PathTOAmcache || RootDrive + "Windows/appcompat/Programs/Amcache.hve"
+    LET PathTOSystem <= S.PathTOSystem || RootDrive + "Windows/System32/Config/System"
+    LET PathTOSecurity <= S.PathTOSecurity || RootDrive + "Windows/System32/Config/Security"
+    LET PathTOSoftware <= S.PathTOSoftware || RootDrive + "Windows/System32/Config/Software"
+    LET PathTOUsers <= S.PathTOUsers || RootDrive + "Users/"
 
     -- HivePath: The path to the hive on disk
     -- RegistryPath: The path in the registry to mount the hive
@@ -186,7 +252,16 @@ export: |
           Description="Map Amcache to /Amcache/"),
     )
 
+    LET _Env = SELECT _value FROM items(item= {
+       SELECT * FROM environ()
+    })
+    LET Env <= _Env[0]._value
+
     LET _api_remapping <= (
+        dict(type="impersonation",
+            os="windows",
+            hostname="RegistryMapper",
+            env=Env),
         -- By default remap the entire "registry" accessor for API access.
         dict(type="mount",
           `from`=dict(accessor="registry", prefix='/', path_type='registry'),
@@ -292,32 +367,6 @@ export: |
     -- This contains the queries for Full Query Rules - they skip the glob and just run arbitrary VQL.
     LET FullQueries <= parse_json_array(data=gunzip(string=base64decode(string="{{ .QueriesJSON }}")))
 
-    LET AllFullQueries <=
-        SELECT * FROM FullQueries
-        WHERE Category =~ CategoryFilter
-          AND Description =~ DescriptionFilter
-
-    -- This contains the metadata for Glob rules.
-    LET _MD <= parse_json_array(data=gunzip(string=base64decode(string="{{.Metadata }}")))
-    LET MD(DescriptionFilter, RootFilter, CategoryFilter, CategoryExcludedFilter) =
-     SELECT Glob, Category, Description,
-            get(field="Details") AS Details,
-            get(field="Comment") AS Comment,
-            get(field="Filter") AS Filter, Root
-     FROM _MD
-     WHERE Description =~ DescriptionFilter
-       AND Root =~ RootFilter
-       AND Category =~ CategoryFilter
-       AND NOT Category =~ CategoryExcludedFilter
-
-    LET AllRules <=
-      SELECT * FROM MD(DescriptionFilter=DescriptionFilter, RootFilter=RootFilter,
-        CategoryFilter=CategoryFilter, CategoryExcludedFilter=CategoryExcludedFilter)
-
-    LET AllGlobs <=
-      SELECT Root, enumerate(items=Glob) AS Globs
-      FROM AllRules
-      GROUP BY Root
 
 sources:
 - name: Remapping
@@ -329,6 +378,16 @@ sources:
 
 - name: Rules
   query: |
+    LET CategoryFilter <= S.CategoryFilter || join(array=Categories, sep="|")
+    LET AllFullQueries <=
+        SELECT * FROM FullQueries
+        WHERE Category =~ CategoryFilter
+          AND Description =~ RuleFilter
+
+    LET AllRules <=
+      SELECT * FROM MD(DescriptionFilter=RuleFilter, RootFilter=RootFilter,
+        CategoryFilter=CategoryFilter, CategoryExcludedFilter=S.CategoryExcludedFilter)
+
     SELECT * FROM chain(a=AllRules, b=AllFullQueries)
   notebook:
   - type: none
@@ -338,6 +397,11 @@ sources:
   - type: none
 
   query: |
+    LET AllGlobs <=
+      SELECT Root, enumerate(items=Glob) AS Globs
+      FROM AllRules
+      GROUP BY Root
+
     SELECT * FROM AllGlobs
 
 - name: Uploads
@@ -381,6 +445,21 @@ sources:
 
    {{- end }}
   query: |
+    LET CategoryFilter <= S.CategoryFilter || join(array=Categories, sep="|")
+    LET AllFullQueries <=
+        SELECT * FROM FullQueries
+        WHERE Category =~ CategoryFilter
+          AND Description =~ RuleFilter
+
+    LET AllRules <=
+      SELECT * FROM MD(DescriptionFilter=RuleFilter, RootFilter=RootFilter,
+        CategoryFilter=CategoryFilter, CategoryExcludedFilter=S.CategoryExcludedFilter)
+
+    LET AllGlobs <=
+      SELECT Root, enumerate(items=Glob) AS Globs
+      FROM AllRules
+      GROUP BY Root
+
     LET GlobsMD <= to_dict(item={
       SELECT Root AS _key, Globs AS _value FROM AllGlobs
     })

--- a/docs/content/docs/rules/index.json
+++ b/docs/content/docs/rules/index.json
@@ -1,1 +1,5685 @@
-[{"Description":"AppCompatCache: AKA ShimCache, data is only written to this value at reboot by winlogon.exe","Category":"Program Execution","Glob":"ControlSet*\\Control\\Session Manager\\AppCompatCache\\AppCompatCache","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eAppCompatCache(Blob=read_file(accessor=\"registry\", filename=OSPath))\n","Filter":"x=\u003etrue","Preamble":["LET AppCompatCacheParser \u003c= '''[\n[\"HeaderWin10\", \"x=\u003ex.HeaderSize\", [\n  [\"HeaderSize\", 0, \"unsigned int\"],\n  [\"Entries\", \"x=\u003ex.HeaderSize\", Array, {\n      type: \"Entry\",\n      sentinel: \"x=\u003ex.Size = 0\",\n      count: 10000,\n      max_count: 10000,\n  }]\n]],\n[\"HeaderWin8\", 128, [\n  [\"Entries\", 128, Array, {\n      type: \"EntryWin8\",\n      sentinel: \"x=\u003ex.EntrySize = 0\",\n      count: 10000,\n      max_count: 10000,\n  }]\n]],\n\n[\"EntryWin8\", \"x=\u003ex.EntrySize + 12\", [\n  [\"Signature\", 0, \"String\", {\n     length: 4,\n  }],\n  [\"EntrySize\", 8, \"unsigned int\"],\n  [\"PathSize\", 12, \"uint16\"],\n  [\"Path\", 14, \"String\", {\n      length: \"x=\u003ex.PathSize\",\n      encoding: \"utf16\",\n  }],\n  [\"LastMod\", \"x=\u003ex.PathSize + 14 + 10\", \"WinFileTime\"]\n]],\n\n[\"Entry\", \"x=\u003ex.Size + 12\", [\n  [\"Signature\", 0, \"String\", {\n     length: 4,\n  }],\n  [\"Size\", 8, \"unsigned int\"],\n  [\"PathSize\", 12, \"uint16\"],\n  [\"Path\", 14, \"String\", {\n      length: \"x=\u003ex.PathSize\",\n      encoding: \"utf16\",\n  }],\n  [\"LastMod\", \"x=\u003ex.PathSize + 14\", \"WinFileTime\"],\n  [\"DataSize\", \"x=\u003ex.PathSize + 14 + 8\", \"uint32\"],\n  [\"Data\", \"x=\u003ex.PathSize + 14 + 8 + 4\" , \"String\", {\n      length: \"x=\u003ex.DataSize\",\n  }],\n\n  # The last byte of the Data block is 1 for execution\n  [\"Execution\", \"x=\u003ex.PathSize + 14 + 8 + 4 + x.DataSize - 4\", \"uint32\"]\n]],\n\n# This is the Win7 parser but we dont use it right now.\n[\"HeaderWin7x64\", 128, [\n  [\"Signature\", 0, \"uint32\"],\n  [\"Entries\", 128, \"Array\", {\n      count: 10000,\n      sentinel: \"x=\u003ex.PathSize = 0\",\n      type: EntryWin7x64,\n  }]\n]],\n[\"EntryWin7x64\", 48, [\n  [\"PathSize\", 0, \"uint16\"],\n  [\"PathOffset\", 8, \"uint32\"],\n  [\"Path\", \"x=\u003ex.PathOffset - x.StartOf\", \"String\", {\n      encoding: \"utf16\",\n      length: \"x=\u003ex.PathSize\",\n  }],\n  [\"LastMod\", 16, \"WinFileTime\"]\n]]\n\n]'''\n\nLET AppCompatCacheWin10(Blob) = parse_binary(\n    accessor=\"data\",\n    filename=Blob,\n    profile=AppCompatCacheParser,\n    struct=\"HeaderWin10\")\n\nLET AppCompatCacheWin8(Blob) = parse_binary(\n    accessor=\"data\",\n    filename=Blob,\n    profile=AppCompatCacheParser,\n    struct=\"HeaderWin8\")\n\nLET AppCompatCache(Blob) = SELECT LastMod, Path, Execution\nFROM foreach(\n  row=if(\n    condition=AppCompatCacheWin10(Blob=Blob).HeaderSize IN (52, 48),\n    then=AppCompatCacheWin10(Blob=Blob).Entries,\n    else=AppCompatCacheWin8(Blob=Blob).Entries))\n"]},{"Description":"AppCompatFlags: Displays programs that are configured to run in Compatibility Mode in Windows","Category":"Program Execution","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags","Root":"HKEY_USERS","Details":"x=\u003edict(Programs=AppCompatFlagsPrograms(OSPath=x.OSPath).Program)\n","Filter":"x=\u003eIsDir","Preamble":["LET AppCompatFlagsPrograms(OSPath) = SELECT OSPath.Basename AS Program\n   FROM glob(globs='Compatibility Assistant/{Store,Persisted}/*',\n             accessor=\"registry\", root=OSPath)\n"]},{"Description":"Rclone","Category":"Threat Hunting","Author":"BusterBaxter5","Comment":"We detect both the config file and registry artifacts from AppCompatFlags","Glob":"","Root":"","Query":"SELECT * FROM chain(a={\n  SELECT Description, Category, OSPath, Mtime,\n       dict(Uploaded=upload(filename=OSPath), Type=\"Config File\") AS Details\n  FROM glob(globs=\"C:\\\\Users\\\\*\\\\AppData\\\\Roaming\\\\rclone\\\\rclone.conf\")\n}, b={\n  SELECT Description, Category, OSPath, Mtime,\n       dict(Path=OSPath.Basename, Data=Data.value) AS Details\n  FROM glob(accessor=\"registry\",\n            globs=\"HKEY_USERS\\\\*\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\AppCompatFlags\\\\Compatibility Assistant\\\\Store\\\\*rclone*\")\n})\n"},{"Description":"DotNetStartupHooks","Category":"Threat Hunting","Author":"Chris Jones - CPIRT | FabFaeb | Antonio Blescia (TheThMando) | bmcder02","Comment":"The .NET DLLs listed in the DOTNET_STARTUP_HOOKS environment\nvariable are loaded into .NET processes at runtime.\n","Glob":"","Root":"","Query":"SELECT OSPath, Data.value AS Value\nFROM glob(globs=[\n'''HKEY_LOCAL_MACHINE\\System\\ControlSet*\\Control\\Session Manager\\Environment\\DOTNET_STARTUP_HOOKS''',\n'''HKEY_USERS\\*\\Environment\\DOTNET_STARTUP_HOOKS'''], accessor=\"registry\")\nWHERE Value\n"},{"Description":"Windows Boot Volume","Category":"System Info","Author":"Andrew Rathbun","Comment":"Identifies the system volume where Windows booted from","Glob":"Setup\\SystemPartition","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"ControlSet Configuration","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays value for the current ControlSet","Glob":"Select\\Current","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"ControlSet Configuration","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays value for the default ControlSet","Glob":"Select\\Default","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"ControlSet Configuration","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays value for the ControlSet that was unable to boot Windows successfully","Glob":"Select\\Failed","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"ControlSet Configuration","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays value for the last known good ControlSet","Glob":"Select\\LastKnownGood","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Shutdown Time","Category":"System Info","Author":"Andrew Rathbun","Comment":"Last system shutdown time","Glob":"ControlSet00*\\Control\\Windows\\ShutdownTime","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFILETIME(t=x.Data)"},{"Description":"Windows OS Language","Category":"System Info","Author":"Andrew Rathbun","Comment":"Default OS Language, 0409 is English","Glob":"ControlSet*\\Control\\Nls\\Language\\InstallLanguage","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Virtual Memory Pagefile Encryption Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Virtual Memory Pagefile Encryption, 0 = Disabled, 1 = Enabled","Glob":"ControlSet*\\Control\\FileSystem\\NtfsEncryptPagingFile","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"TRIM Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"TRIM, 0 = Enabled, 1 = Disabled","Glob":"ControlSet*\\Control\\FileSystem\\DisableDeleteNotification","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"NTFS File Compression Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"NTFS File Compression, 0 = Enabled, 1 = Disabled","Glob":"ControlSet*\\Control\\FileSystem\\NtfsDisableCompression","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"NTFS File Encryption Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"NTFS File Encryption, 0 = Enabled, 1 = Disabled","Glob":"ControlSet*\\Control\\FileSystem\\NtfsDisableEncryption","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"NTFS LastAccess Timestamp Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"NTFS LastAccess Timestamp, 2147483650 = Enabled, 1 = Disabled","Glob":"ControlSet*\\Control\\FileSystem\\NtfsDisableLastAccessUpdate","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Long Paths Enabled","Category":"System Info","Author":"Andrew Rathbun","Comment":"NTFS Long Paths, 0 = Disabled, 1 = Enabled","Glob":"ControlSet*\\Control\\FileSystem\\LongPathsEnabled","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Prefetch Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"0 = Disabled, 1 = Application Prefetching Enabled, 2 = Boot Prefetching Enabled, 3 = Application and Boot Prefetching Enabled","Glob":"ControlSet00*\\Control\\Session Manager\\Memory Management\\PrefetchParameters\\EnablePrefetcher","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Clear Page File at Shutdown Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"0 = Disabled, 1 = Enabled","Glob":"ControlSet00*\\Control\\Session Manager\\Memory Management\\ClearPageFileAtShutdown","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"System Time Zone Information","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays the current Time Zone configuration for this system","Glob":"ControlSet00*\\Control\\TimeZoneInformation","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)","Filter":"x=\u003etrue"},{"Description":"Network Connections","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays list of network connections","Glob":"Microsoft\\Windows NT\\CurrentVersion\\NetworkList","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(\n   Profiles={\n     SELECT ProfileName, Description, Managed,\n            Category, CategoryType, GetDateFrom128Bit(x= DateCreated) AS DateCreated,\n            GetDateFrom128Bit(x=DateLastConnected) AS DateLastConnected\n     FROM read_reg_key(root=x.OSPath, globs=\"Profiles/*\")\n  },\n   Signatures={\n     SELECT Key.OSPath[-2:] AS Key,\n            FormatMAC(x=DefaultGatewayMac) AS DefaultGatewayMac,\n            DnsSuffix, ProfileGuid,\n            FirstNetwork\n     FROM read_reg_key(root=x.OSPath,\n          globs=\"/Signatures/*/*\")\n  }\n)\n","Filter":"x=\u003etrue"},{"Description":"Device Classes","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays a list of PnP devices (Plug and Play) that were connected to this system","Glob":"ControlSet*\\Control\\DeviceClasses\\*\\##*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eparse_string_with_regex(string=x.OSPath.Basename,\n     regex=\"##\\\\?#(?P\u003cType\u003e[^#]+)#(?P\u003cName\u003e[^#]+)#(?P\u003cserialNumber\u003e[^#]+)#(?P\u003cClass\u003e.+)\")\n","Filter":"x=\u003etrue"},{"Description":"System Info (Current)","Category":"System Info","Author":"Andrew Rathbun","Comment":"Current OS install time","Glob":"Microsoft\\Windows NT\\CurrentVersion\\InstallTime","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFILETIME(t=x.Data)"},{"Description":"Network Adapters","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays list of network adapters connected to this system","Glob":"ControlSet*\\Control\\Class\\?4d36e972-e325-11ce-bfc1-08002be10318?\\00*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n  InstallTimeStamp=GetDateFrom128Bit(x=GetValue(OSPath=x.OSPath + \"InstallTimeStamp\")),\n  NetworkInterfaceInstallTimestamp=FILETIME(t=GetValue(OSPath=x.OSPath + \"NetworkInterfaceInstallTimestamp\"))\n)\n","Filter":"x=\u003etrue"},{"Description":"Windows 10 Timeline Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Windows 10 Activity Timeline status, 0 = Disabled, 1 = Enabled","Glob":"Policies\\Microsoft\\Windows\\System\\EnableActivityFeed","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows 10 Timeline Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Windows 10 Activity Timeline status, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\PolicyManager\\default\\Privacy\\EnableActivityFeed\\value","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Clipboard History Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays the status of Clipboard History, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\PolicyManager\\default\\Privacy\\EnableClipboardHistory","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Clipboard History Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays the status of Clipboard Sync Across Devices, 0 = Disabled, 1 = Enabled","Glob":"Software\\Policies\\Microsoft\\Windows\\System\\AllowCrossDeviceClipboard","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Clipboard History Status","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays the status of Clipboard Sync Across Devices, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\PolicyManager\\default\\Privacy\\AllowCrossDeviceClipboard\\value","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"User Access Logging (SUM DB)","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays the updating interval for the SUM DB. Default is 24 hours. 60000 = 60 seconds, for example","Glob":"ControlSet*\\Control\\WMI\\Autologger\\SUM\\PollingInterval","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"MAC Addresses","Category":"System Info","Author":"Andrew Rathbun","Comment":"Displays MAC Addresses related to this system. This key normally gets Permission Denied when using the API - use Raw Hives to access","Glob":"ControlSet00*\\Control\\NetworkSetup2\\Interfaces\\*\\Kernel","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n   PermanentAddress=FormatMAC(x=GetValue(OSPath=x.OSPath + \"PermanentAddress\") || \"\"),\n   CurrentAddress=FormatMAC(x=GetValue(OSPath=x.OSPath + \"CurrentAddress\") || \"\")\n)\n","Filter":"x=\u003etrue"},{"Description":"Bluetooth Devices","Category":"Devices","Author":"Andrew Rathbun","Comment":"Displays the Bluetooth devices that have been connected to this computer","Glob":"ControlSet*\\Services\\BTHPORT\\Parameters\\Devices\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)","Filter":"x=\u003etrue"},{"Description":"Volume Info Cache","Category":"Devices","Author":"Andrew Rathbun","Comment":"2 = Removable, 3 = Fixed, 4 = Network, 5 = Optical, 6 = RAM disk, 0 = Unknown","Glob":"Microsoft\\Windows Search\\VolumeInfoCache\\*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n   DriveName=x.OSPath.Basename,\n   DriveType=ExtractValueFromComment(x=GetValue(OSPath=x.OSPath + \"DriveType\"))\n)\n","Filter":"x=\u003etrue"},{"Description":"USBSTOR","Category":"Devices","Author":"Andrew Rathbun","Comment":"Displays list of USB devices that have been plugged into this system. If \u0026 is second character within serial number, serial number is only unique on the system","Glob":"ControlSet*\\Enum\\USBSTOR\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003edict(\n  Name=x.OSPath.Basename,\n  Manufacturer=split(string=x.OSPath.Basename, sep=\"\u0026\")[1],\n  Title=split(string=x.OSPath.Basename, sep=\"\u0026\")[2],\n  Version=split(string=x.OSPath.Basename, sep=\"\u0026\")[3],\n  Instance={\n    SELECT OSPath.Basename AS Serial, dict(\n       DeviceName=utf16(string=GetRawValue(OSPath=OSPath + \"/Properties/{540b947e-8b40-45bc-a8a2-6a0b894cbda2}/0004/@\")),\n       Installed=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0064/@\")),\n       FirstInstalled=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0065/@\")),\n       LastConnected=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0066/@\")),\n       LastRemoved=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0067/@\"))\n    ) AS Properties,\n    to_dict(item={\n       SELECT OSPath.Basename AS _key, Data.value AS _value\n       FROM glob(globs=\"*\", accessor=\"registry\", root=OSPath)\n    }) AS Metadata\n    FROM glob(globs='*', root=x.OSPath, accessor=\"raw_registry\")\n  }\n)\n","Filter":"x=\u003etrue"},{"Description":"USB","Category":"Devices","Author":"Andrew Rathbun","Comment":"Provides VID and PID numbers of USB devices. Match serial number from USBSTOR and search for VID and PID across the system","Glob":"ControlSet*\\Enum\\USB\\VID_*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003edict(\n  Name=x.OSPath.Basename,\n  Vid=split(string=x.OSPath.Basename, sep=\"\u0026\")[0],\n  Pid=split(string=x.OSPath.Basename, sep=\"\u0026\")[1],\n  Instance={\n    SELECT OSPath.Basename AS Serial, dict(\n       DeviceName=utf16(string=GetRawValue(OSPath=OSPath + \"/Properties/{540b947e-8b40-45bc-a8a2-6a0b894cbda2}/0004/@\")),\n       Installed=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0064/@\")),\n       FirstInstalled=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0065/@\")),\n       LastConnected=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0066/@\")),\n       LastRemoved=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0067/@\"))\n    ) AS Properties,\n    to_dict(item={\n       SELECT OSPath.Basename AS _key, Data.value AS _value\n       FROM glob(globs=\"*\", accessor=\"registry\", root=OSPath)\n    }) AS Metadata\n    FROM glob(globs='*', root=x.OSPath, accessor=\"raw_registry\")\n  }\n)\n","Filter":"x=\u003eIsDir"},{"Description":"MountPoints2","Category":"Devices","Author":"Andrew Rathbun","Comment":"Mount Points - NTUSER","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\MountPoints2\\**","Root":"HKEY_USERS"},{"Description":"Mounted Devices","Category":"Devices","Author":"Andrew Rathbun","Comment":"Last Write Timestamp is for entire key, not each individual value","Glob":"MountedDevices","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Windows Portable Devices","Category":"Devices","Author":"Andrew Rathbun","Comment":"Displays list of USB devices previously connected to this system","Glob":"Microsoft\\Windows Portable Devices","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"SCSI","Category":"Devices","Author":"Andrew Rathbun","Comment":"Displays a list of SCSI devices connected to this system","Glob":"ControlSet*\\Enum\\SCSI","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Network Shares","Category":"Network Shares","Author":"Andrew Rathbun","Comment":"Displays the UNC path for a mounted network share","Glob":"*\\Network\\**\\RemotePath","Root":"HKEY_USERS"},{"Description":"Network Shares","Category":"Network Shares","Author":"Andrew Rathbun","Comment":"Displays the user account associated with the mounted network share","Glob":"*\\Network\\**\\UserName","Root":"HKEY_USERS"},{"Description":"Network Shares","Category":"Network Shares","Author":"Andrew Rathbun","Comment":"Displays the provider of the mounted network share","Glob":"*\\Network\\**\\ProviderName","Root":"HKEY_USERS"},{"Description":"Network Drive MRU","Category":"Network Shares","Author":"Andrew Rathbun","Comment":"Displays drives that were mapped by the user","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Map Network Drive MRU","Root":"HKEY_USERS"},{"Description":"Network Shares","Category":"Network Shares","Author":"Andrew Rathbun","Comment":"Displays the share names and permissions of network shares","Glob":"ControlSet00*\\Services\\LanmanServer\\Shares\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"User Accounts (SAM)","Category":"User Accounts","Author":"Andrew Rathbun","Comment":"User accounts in SAM hive","Glob":"SAM\\Domains\\Account\\Users","Root":"SAM"},{"Description":"User Accounts (SOFTWARE)","Category":"User Accounts","Author":"Andrew Rathbun","Comment":"User accounts in SOFTWARE hive","Glob":"Microsoft\\Windows NT\\CurrentVersion\\ProfileList","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"User Accounts (SECURITY)","Category":"User Accounts","Author":"Andrew Rathbun","Comment":"Built-in accounts in SECURITY hive","Glob":"Policy\\Accounts\\*","Root":"HKEY_LOCAL_MACHINE\\Security"},{"Description":"Built-in User Accounts (SAM)","Category":"User Accounts","Author":"Andrew Rathbun","Comment":"Built-in accounts in SAM hive","Glob":"SAM\\Domains\\Builtin\\Aliases","Root":"SAM"},{"Description":"Sysinternals","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays all SysInternals Tools that had the EULA accepted, indicating either execution of the tool or the Registry values were added intentionally prior to execution","Glob":"*\\SOFTWARE\\Sysinternals\\*\\EulaAccepted","Root":"HKEY_USERS","Details":"x=\u003edict(Program=x.OSPath[-2], FirstRunTimestamp=x.Mtime)\n"},{"Description":"RecentApps","Category":"Program Execution","Author":"Andrew Rathbun","Comment":"RecentApps","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Search\\RecentApps\\**","Root":"HKEY_USERS"},{"Description":"MuiCache (Vista+)","Category":"Program Execution","Author":"Andrew Rathbun","Comment":"Displays new applications that have been executed within Windows","Glob":"*\\Software\\ClassesLocal Settings\\Software\\Microsoft\\Windows\\Shell\\MuiCache","Root":"HKEY_USERS"},{"Description":"MuiCache (2000/XP/2003)","Category":"Program Execution","Author":"Andrew Rathbun","Comment":"Displays new applications that have been executed within Windows","Glob":"*\\Software\\ClassesSoftware\\Microsoft\\Windows\\ShellNoRoam\\MUICache","Root":"HKEY_USERS"},{"Description":"Pinned Taskbar Items","Category":"User Activity","Author":"Andrew Rathbun","Comment":"Displays pinned Taskbar items","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TaskBand\\Favorites","Root":"HKEY_USERS"},{"Description":"TypedPaths","Category":"User Activity","Author":"Andrew Rathbun","Comment":"Displays paths that were typed by the user in Windows Explorer","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TypedPaths","Root":"HKEY_USERS"},{"Description":"TypedURLs","Category":"User Activity","Author":"Andrew Rathbun","Comment":"Internet Explorer/Edge Typed URLs","Glob":"*\\Software\\Microsoft\\Internet Explorer\\TypedURLs","Root":"HKEY_USERS"},{"Description":"Microsoft Office MRU","Category":"User Activity","Author":"Andrew Rathbun","Comment":"Microsoft Office Recent Files, lower Item value (Value Name) = more recent","Glob":"*\\SOFTWARE\\Microsoft\\Office\\*\\*\\User MRU\\*\\File MRU","Root":"HKEY_USERS"},{"Description":"FirstFolder","Category":"User Activity","Author":"Andrew Rathbun","Comment":"FirstFolder, tracks the application's first folder that is presented to the user during an Open or Save As operation","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\FirstFolder\\**","Root":"HKEY_USERS"},{"Description":"RunNotification","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"New in Windows 11, compare with other more researched Autoruns artifacts","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunNotification","Root":"HKEY_USERS"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run\\**","Root":"HKEY_USERS"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run32\\**","Root":"HKEY_USERS"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder\\**","Root":"HKEY_USERS"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run32\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Startup Programs","Category":"Autoruns","Author":"Andrew Rathbun","Comment":"Displays list of programs that start up upon system boot","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"VNC Viewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays artifactrs relating to VNC Viewer","Glob":"*\\Software\\RealVNC\\vncviewer\\**","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the name of the QNAP as it was assigned by the user","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrName","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the IP Address of the QNAP as it was assigned by the user","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrIPAddr","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the current firmware version of the QNAP","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrVersion","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the type of the QNAP device","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrType","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the model of the QNAP device","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrModel","Root":"HKEY_USERS"},{"Description":"QNAP QFinder","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the install date of QNAP QFinder","Glob":"*\\SOFTWARE\\QNAP\\Qfinder\\InstallDate","Root":"HKEY_USERS"},{"Description":"Total Commander","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Total Commander Registry artifacts","Glob":"Ghisler\\Total Commander","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Total Commander","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Total Commander Registry artifacts","Glob":"WOW6432Node\\Ghisler\\Total Commander","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"TeamViewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Windows username of logged in user","Glob":"*\\Software\\TeamViewer\\Meeting_UserName","Root":"HKEY_USERS"},{"Description":"TeamViewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"User's email associated with TeamViewer","Glob":"*\\Software\\TeamViewer\\BuddyLoginName","Root":"HKEY_USERS"},{"Description":"TeamViewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"User specified TeamViewer display name","Glob":"*\\Software\\TeamViewer\\BuddyDisplayName","Root":"HKEY_USERS"},{"Description":"TeamViewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the name of the user logged into TeamViewer","Glob":"WOW6432Node\\TeamViewer\\OwningManagerAccountName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"TeamViewer","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the date the password was last set for the user within TeamViewer","Glob":"WOW6432Node\\TeamViewer\\PermanentPasswordDate","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Adobe cRecentFiles","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays files which were opened Adobe Reader by the user","Glob":"*\\Software\\Adobe","Root":"HKEY_USERS"},{"Description":"Adobe cRecentFolders","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays folders where Adobe Reader opened a PDF file from","Glob":"*\\Software\\Adobe\\Acrobat Reader\\DC\\AVGeneral\\cRecentFolders\\*\\tDIText","Root":"HKEY_USERS"},{"Description":"VisualStudio FileMRUList","Category":"User Activity","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\VisualStudio\\*\\FileMRUList","Root":"HKEY_USERS"},{"Description":"VisualStudio MRUItems","Category":"User Activity","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\VisualStudio\\*\\MRUItems\\*\\Items","Root":"HKEY_USERS"},{"Description":"VisualStudio MRUSettings","Category":"User Activity","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\VisualStudio\\*\\NewProjectDialog\\MRUSettingsLocalProjectLocationEntries","Root":"HKEY_USERS"},{"Description":"7-Zip","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays list of files and folders that were used with 7-Zip","Glob":"*\\Software\\7-Zip\\Compression\\ArcHistory","Root":"HKEY_USERS"},{"Description":"WinRAR","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays history of archives that were used with WinRAR","Glob":"*\\Software\\WinRAR","Root":"HKEY_USERS"},{"Description":"Eraser","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Potential evidence of anti-forensics","Glob":"*\\Software\\Eraser\\**","Root":"HKEY_USERS"},{"Description":"LogMeIn","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"LogMeIn GoToMeeting","Glob":"*\\Software\\LogMeIn\\**","Root":"HKEY_USERS"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Macrium Reflect image storage directory","Glob":"*\\Software\\Macrium\\Reflect\\Recent Folders\\Image\\*","Root":"HKEY_USERS"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays files that are not to be included in Macrium Reflect images","Glob":"ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshotMacriumImage\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Command last ran by user","Glob":"Macrium\\**\\LastRun","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"registered user","Glob":"Macrium\\**\\Licensee","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays timestamps related to Macrium Reflect's CBT feature","Glob":"Macrium\\Reflect\\CBT\\Sequence\\**","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFILETIME(t=x.Data)"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays default settings associated with Macrium Reflect on this computer","Glob":"Macrium\\Reflect\\Defaults\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays Macrium Image Guardian status","Glob":"Macrium\\Reflect\\ImageGuardian","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays SID associated with Macrium Reflect on this computer","Glob":"Macrium\\Reflect\\Security\\**\\SID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the application path associated with Macrium Reflect on this computer","Glob":"Macrium\\Reflect\\Security\\**\\App Path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Macrium Image Guardian Status, 1 = protected","Glob":"Macrium\\Reflect\\MIG\\Verified\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Macrium Reflect","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays settings related to Macrium Reflect's interaction with VSS","Glob":"Macrium\\Reflect\\VSS\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"WinSCP","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"WinSCP","Glob":"*\\Software\\Martin Prikryl\\**","Root":"HKEY_USERS"},{"Description":"WinSCP","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"WinSCP","Glob":"WOW6432Node\\Martin Prikryl\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Ares","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays information relating to Ares","Glob":"Ares\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Soulseek","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the name of the user who installed Soulseek","Glob":"WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\?8A4E1646-488C-4E5B-AC31-F784400E8D2D?_is1\\**\\Inno Setup: User","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Soulseek","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the language for which Soulseek was installed","Glob":"WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\?8A4E1646-488C-4E5B-AC31-F784400E8D2D?_is1\\**\\Inno Setup: Language","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Signal","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the location where Signal is installed on the user's computer","Glob":"*\\Software\\7d96caee-06e6-597c-9f2f-c7bb2e0948b4\\**\\InstallLocation","Root":"HKEY_USERS"},{"Description":"Stardock Fences","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays a list of links the user had on their desktop at the time of installation","Glob":"*\\Software\\Stardock\\Fences\\InitialSnapshot\\**","Root":"HKEY_USERS"},{"Description":"Stardock Fences","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays a list of icons on the user's desktop","Glob":"*\\Software\\Stardock\\Fences\\Icons\\**","Root":"HKEY_USERS"},{"Description":"Stardock Fences","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays a list of connected monitors to the user's computer","Glob":"*\\Software\\Stardock\\Fences\\Settings\\**\\ResolutionLast","Root":"HKEY_USERS"},{"Description":"Stardock Fences","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the user's primary monitor","Glob":"*\\Software\\Stardock\\Fences\\Settings\\**\\PrimaryMonitorLast","Root":"HKEY_USERS"},{"Description":"4K Video Downloader","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the run count for 4K Video Downloader","Glob":"*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Notification\\runCount","Root":"HKEY_USERS"},{"Description":"4K Video Downloader","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the last version of 4K Video Downloader installed on this system","Glob":"*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Notification\\lastVersion","Root":"HKEY_USERS"},{"Description":"4K Video Downloader","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the date that 4K Video Downloader was installed","Glob":"*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Limits\\dayDownloadDate","Root":"HKEY_USERS","Details":"x=\u003etimestamp(epoch=x.Data)"},{"Description":"4K Video Downloader","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the amount of times 4K Video Downloaded was downloaded","Glob":"*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Limits\\dayDownloadCount","Root":"HKEY_USERS"},{"Description":"4K Video Downloader","Category":"Third Party Applications","Author":"Andrew Rathbun","Comment":"Displays the location of the SQLite database associated with 4K Video Downloader","Glob":"*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Download\\downloadedItemsDb","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays folders present within a user's OneDrive","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Internet\\Server*\\http*\\*","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the user's (check HivePath) specified storage location for OneDrive","Glob":"*\\Environment\\OneDriveConsumer","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the user's specified storage location for OneDrive","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\OneDrive*\\UserSyncRoots\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the Last Modified time for the OneDrive Registry key","Glob":"*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\LastModifiedTime","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays where the OneDrive folder is mounted","Glob":"*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\MountPoint","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the URL Namespace for OneDrive","Glob":"*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\UrlNamespace","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Office Sync Integration, 0 = Disabled, 1 = Enabled","Glob":"*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\IsOfficeSyncIntegrationEnabled","Root":"HKEY_USERS","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Glob":"*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\LibraryType","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the installation path from the user's AppData folder for OneDrive","Glob":"*\\Software\\Microsoft\\OneDrive\\*\\**\\InstallPath","Root":"HKEY_USERS"},{"Description":"OneDrive","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the last update time of the Accounts OneDrive Registry key","Glob":"*\\Software\\Microsoft\\OneDrive\\Accounts\\**\\LastUpdate","Root":"HKEY_USERS","Details":"x=\u003etimestamp(epoch=x.Data)"},{"Description":"Dropbox","Category":"Cloud Storage","Author":"Andrew Rathbun","Comment":"Displays the user's specified storage location for Dropbox","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\Dropbox*\\UserSyncRoots\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Event Logs Logging Status","Category":"Event Logs","Author":"Andrew Rathbun","Comment":"Displays the status of Windows Event Log Channels (Key Path) on this system, 0 = Disabled, 1 - Enabled","Glob":"Microsoft\\Windows\\CurrentVersion\\WINEVT\\Channels\\**\\Enabled","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Application Event Log Providers","Category":"Event Logs","Author":"Andrew Rathbun","Comment":"Displays the status of Providers within the Application Event Log on this system, 0 = Disabled, 1 - Enabled","Glob":"ControlSet001\\Control\\WMI\\Autologger\\EventLog-Application\\**","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"System Event Log Providers","Category":"Event Logs","Author":"Andrew Rathbun","Comment":"Displays the status of Providers within the Application Event Log on this system, 0 = Disabled, 1 - Enabled","Glob":"ControlSet001\\Control\\WMI\\Autologger\\EventLog-System\\**","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists email addresses registered to Microsoft Office on the user's system","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\EmailAddresses","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists email address registered to Microsoft Office on the user's system","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\EmailAddress","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists first name for the registered Microsoft Office user","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\FirstName","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists last name for the registered Microsoft Office user","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\LastName","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists full name for the registered Microsoft Office user","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\FriendlyName","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Lists initials for the registered Microsoft Office user","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\Initials","Root":"HKEY_USERS"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Displays time user was authenticated to the system's instance of Microsoft 365 for the first time","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\AuthHistory\\**","Root":"HKEY_USERS","Details":"x=\u003eFILETIME(t=x.Data)"},{"Description":"Microsoft Office","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Displays time user was authenticated to the system's instance of Microsoft 365 for the first time","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Profiles\\*\\**","Root":"HKEY_USERS"},{"Description":"Microsoft Office Trusted Documents","Category":"Microsoft Office","Author":"Andrew Rathbun","Comment":"Displays list of Office documents where the user may have clicked Enable Editing, Enable Macro, or Enable Content","Glob":"*\\Software\\Microsoft\\Office\\*\\*\\Security\\Trusted Documents\\TrustRecords\\**","Root":"HKEY_USERS"},{"Description":"Microsoft Exchange Patch Status","Category":"Microsoft Exchange","Author":"Andrew Rathbun","Comment":"Displays the date the patch was installed on this host","Glob":"Microsoft\\Updates\\Exchange*\\KB*\\InstalledDate","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Exchange Patch Status","Category":"Microsoft Exchange","Author":"Andrew Rathbun","Comment":"Displays the name of the patch installed on this host","Glob":"Microsoft\\Updates\\Exchange*\\KB*\\PackageName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Exchange Patch Status","Category":"Microsoft Exchange","Author":"Andrew Rathbun","Comment":"Displays the date the patch was installed on this host","Glob":"Microsoft\\Updates\\Exchange*\\SP*\\KB*\\InstalledDate","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Exchange Patch Status","Category":"Microsoft Exchange","Author":"Andrew Rathbun","Comment":"Displays the name of the patch installed on this host","Glob":"Microsoft\\Updates\\Exchange*\\SP*\\KB*\\PackageName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Google Chrome","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Google Chrome Registry artifacts","Glob":"*\\Software\\Google\\Chrome\\**","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Main","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Download Directory","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\NewWindows","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Suggested Sites\\*","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\ProtocolExecute\\*","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\LowRegistry\\IEShims\\**","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Main\\WindowsSearch\\**","Root":"HKEY_USERS"},{"Description":"Internet Explorer","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Internet Explorer Registry artifacts","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Main\\WindowsSearch","Root":"HKEY_USERS"},{"Description":"Microsoft Edge","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"Microsoft Edge Registry artifacts","Glob":"*\\Software\\Microsoft\\Edge\\**","Root":"HKEY_USERS"},{"Description":"CCleaner Browser","Category":"Web Browsers","Author":"Andrew Rathbun","Comment":"CCleaner Browser Registry artifacts","Glob":"WOW6432Node\\Piriform\\Browser\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"File Extensions","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Tracks programs associated with file extensions","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts","Root":"HKEY_USERS"},{"Description":"Add/Remove Programs Entries","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays installed software","Glob":"Microsoft\\Windows\\CurrentVersion\\Uninstall","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Add/Remove Programs Entries","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays installed software","Glob":"WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Add/Remove Programs Entries","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays installed software","Glob":"*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall","Root":"HKEY_USERS"},{"Description":"Products","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays all installed software packages","Glob":"Microsoft\\Windows\\CurrentVersion\\Installer\\UserData\\*\\Products","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows App List","Category":"Installed Software","Author":"Andrew Rathbun","Comment":"Displays all Windows applications installed on this system","Glob":"*\\Software\\ClassesLocal Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\Repository","Root":"HKEY_USERS"},{"Description":"VSS","Category":"Volume Shadow Copies","Author":"Andrew Rathbun","Comment":"Displays files to be deleted from newly created shadow copies","Glob":"ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshot\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"VSS","Category":"Volume Shadow Copies","Author":"Andrew Rathbun","Comment":"Displays files to be deleted from newly created shadow copies","Glob":"ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshotSave\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"VSS","Category":"Volume Shadow Copies","Author":"Andrew Rathbun","Comment":"Displays the names of the Registry subkeys and values that backup applications should not restore","Glob":"ControlSet*\\Control\\BackupRestore\\KeysNotToRestore\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"VSS","Category":"Volume Shadow Copies","Author":"Andrew Rathbun","Comment":"Displays the names of the files and directories that backup applications should not backup or restore","Glob":"ControlSet*\\Control\\BackupRestore\\FilesNotToBackup\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Shadow RDP Sessions","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Shadow RDP sessions, 0 = Disabled, 1 = Full Control with user's permission, 2 = Full Control without user's permission, 3 = View Session with user's permission, 4 = View Session without user's permission","Glob":"Policies\\Microsoft\\Windows NT\\Terminal Services\\**\\Shadow","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"RDP Connections Status","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the status of whether the system can accept Terminal Server (RDP) connections, 0 = Disabled (Inbound RDP enabled), 1 = Enabled (Inbound RDP disabled)","Glob":"ControlSet*\\Control\\Terminal Server\\**\\fDenyTSConnections","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"RDP User Authentication Status","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays whether a Network-Level user authentication is required before a remote desktop connection is established. 0 = Disabled (no authentication required), 1 = Enabled (authentication required)","Glob":"ControlSet*\\Control\\Terminal Server\\WinStations\\RDP-Tcp\\**\\UserAuthentication","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender Status","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the status of whether Windows Defender AntiSpyware is enabled or not. 0 = Enabled, 1 = Disabled","Glob":"Policies\\Microsoft\\Windows Defender\\**\\DisableAntiSpyware","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender Status","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the status of whether Windows Defender AntiVirus is enabled or not. 0 = Enabled, 1 = Disabled","Glob":"Policies\\Microsoft\\Windows Defender\\**\\DisableAntiVirus","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender","Category":"Antivirus","Author":"Andrew Rathbun","Comment":"Windows Defender DisableBlockAtFirstSeen Status, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender","Category":"Antivirus","Author":"Andrew Rathbun","Comment":"Windows Defender SpynetReporting Status, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\Windows Defender\\SpyNet\\SpynetReporting","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender","Category":"Antivirus","Author":"Andrew Rathbun","Comment":"Windows Defender SubmitSamplesConsent Status, 0 = Disabled, 1 = Enabled","Glob":"Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"PortProxy Configuration","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays current port proxy configuration","Glob":"ControlSet*\\Services\\PortProxy\\v4tov4\\tcp\\**","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Exefile Shell Open Command","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Exefile hijack shows e.g. path to a binary","Glob":"Classes\\Exefile\\Shell\\Open\\Command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Exefile Shell Open Command","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Exefile hijack shows e.g. path to a binary","Glob":"*\\Software\\ClassesExefile\\Shell\\Open\\Command\\@","Root":"HKEY_USERS"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"0 = Disabled, 1 = Enabled","Glob":"Policies\\Microsoft\\Windows\\System\\UseAdvancedStartup","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"1 = Default, 0 = Disabled, 1 = Enabled","Glob":"Policies\\Microsoft\\Windows\\System\\EnableBDEWithNoTPM","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"0 = Do Not Allow TPM, 1 = Require TPM, 2 = Allow TPM","Glob":"Policies\\Microsoft\\Windows\\System\\UseTPM","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"0 = Do not allow startup key with TPM, 1 = Require startup key with TPM, 2 = Allow startup key with TPM","Glob":"Policies\\Microsoft\\Windows\\System\\UseTPMKey","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"0 = Do not allow startup key and PIN with TPM, 1 = Require startup key and PIN with TPM, 2 = Allow startup key and PIN with TPM","Glob":"Policies\\Microsoft\\Windows\\System\\UseTPMKeyPIN","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the Recovery Key message set by the Threat Actor group","Glob":"Policies\\Microsoft\\Windows\\System\\RecoveryKeyMessage","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"2 is set by the Hades group","Glob":"Policies\\Microsoft\\Windows\\System\\RecoveryKeyMessageSource","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Hades IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"0 = Do not allow startup PIN with TPM, 1 = Require startup PIN with TPM, 2 = Allow startup PIN with TPM","Glob":"Policies\\Microsoft\\Windows\\System\\UseTPMPIN","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"REvil IOCs","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"REvil/Kaseya Ransomware attack from July 2021","Glob":"Wow6432Node\\BlackLivesMatter\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"PowerShell Info","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Cobalt Strike Reflection Attack - Lockbit 2.0","Glob":"Microsoft\\PowerShell\\info","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Restricted Admin Status","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the status of Restricted Admin mode","Glob":"ControlSet*\\Control\\Lsa\\DisableRestrictedAdmin","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Windows Defender","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled","Glob":"Microsoft\\Windows Defender\\Real-Time Protection","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Symantec Endpoint Protection","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays a list of filenames that have been quarantined by Symantec Endpoint Protection","Glob":"WOW6432Node\\Symantec\\Symantec Endpoint Protection\\AV\\Quarantine\\QRecords\\*\\FName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows Defender","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled","Glob":"Microsoft\\Windows Defender\\Reporting","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled","Glob":"Microsoft\\Windows Defender\\fDenyTSConnections","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eExtractValueFromComment(x=x)"},{"Description":"Windows Defender","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Windows Defender Exclusions through Group Policies (GPOs)","Glob":"Policies\\Microsoft\\Windows Defender\\Exclusions\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows Defender","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Windows Defender Exclusions","Glob":"Microsoft\\Windows Defender\\Exclusions\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Image File Execution Options Injection","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"See documentation in Batch File for further information","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\Debugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Image File Execution Options Injection","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"See documentation in Batch File for further information","Glob":"Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Connections Made By MS Office","Category":"Threat Hunting","Author":"Andrew Rathbun","Comment":"Displays the connections made by MS Office - IOCs found here for CVE-2022-30190","Glob":"*\\Software\\Microsoft\\Office\\*\\Common\\Internet\\Server Cache\\**","Root":"HKEY_USERS"},{"Description":"Select ControlSet","Category":"ASEP","Author":"Troy Larson","Glob":"Select","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"ServiceControlManagerExtension","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\ServiceControlManagerExtension","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"BootVerificationProgram","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\BootVerificationProgram\\Imagepath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"LSA Authentication Packages","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\LSA\\Authentication Packages","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"LSA Notification Packages","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\LSA\\Notification Packages","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"LSA Security Packages","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\LSA\\Security Packages","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"LSA OsConfig","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\LSA\\OsConfig\\Security Packages","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"NetworkProvider Order","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\NetworkProvider\\*\\**\\ProviderOrder","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Print Driver","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Print\\Monitors\\*\\**\\Driver","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Print Providers","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Print\\Providers\\*\\**\\Name","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"SafeBoot","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\SafeBoot\\AlternateShell","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"SafeBoot Minimal","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\SafeBoot\\Minimal\\*\\**\\@","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"SafeBoot Network","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\SafeBoot\\Network\\*\\**\\@","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"SecurityProviders","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\SecurityProviders\\SecurityProviders","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager BootExecute","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\BootExecute","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager BootShell","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\BootShell","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager Execute","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\Execute","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager InitialCommand","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\InitialCommand","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager InitialCommand","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\*InitialCommand","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager PendingFileRenameOperations","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\PendingFileRenameOperations","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager PendingFileRenameOperations*","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\PendingFileRenameOperations*","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager SETUPEXECUTE","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\SetUpExecute","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager KnownDLLs","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\KnownDLLs","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Session Manager SubSystems","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Session Manager\\SubSystems","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Terminal Server StartupPrograms","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Terminal Server\\Wds\\rdpwd\\StartupPrograms","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Terminal Server WinStations RDP-Tcp","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\Terminal Server\\WinStations\\RDP-Tcp\\TSMMRemotingAllowedApps","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WOW KnownDLLs","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Control\\WOW\\KnownDLLs","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services AutoRun","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\AutoRun","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services BootFlags","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\BootFlags","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services DelayedAutoStart","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\DelayedAutoStart","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services DependOnService","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\DependOnService","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services Description","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\Description","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services DisplayName","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\DisplayName","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ErrorControl","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ErrorControl","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services Group","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\Group","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ImagePath","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ImagePath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services Library","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\Library","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ObjectName","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ObjectName","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ProviderPath","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ProviderPath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ProxyDllFile","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ProxyDllFile","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services RequiredPrivileges","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\RequiredPrivileges","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ServiceDll","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ServiceDll","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ServiceMain","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ServiceMain","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services ServiceSidType","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\ServiceSidType","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services Start","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\Start","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Services Type","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\*\\**\\Type","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 AppId_Catalog AppFullPath","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\AppId_Catalog\\*\\AppFullPath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 AppId_Catalog AppArgs","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\AppId_Catalog\\*\\AppArgs","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 DisplayString","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\DisplayString","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 Enabled","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\Enabled","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 LibraryPath","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\LibraryPath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 64 DisplayString","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\DisplayString","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 64 Enabled","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\Enabled","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 NameSpace_Catalog5 64 LibraryPath","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\LibraryPath","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 Protocol_Catalog9 ProtocolName","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\Protocol_Catalog9\\Catalog_Entries\\*\\ProtocolName","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"WinSock2 Protocol_Catalog9 64 ProtocolName","Category":"ASEP","Author":"Troy Larson","Glob":"ControlSet*\\Services\\WinSock2\\Parameters\\Protocol_Catalog9\\Catalog_Entries64\\*\\ProtocolName","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Setup","Category":"ASEP","Author":"Troy Larson","Glob":"Setup\\CmdLine","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":".cmd","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\.cmd\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":".cmd PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\.cmd\\PersistentHandler\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":".exe","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\.exe\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":".exe PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\.exe\\PersistentHandler\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shell Open Command","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shell\\**\\DelegateExecute","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shell Runas command","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shell\\**\\IsolatedCommand","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx ColumnHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\ColumnHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx ContextMenuHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\ContextMenuHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shellex ContextMenuHandlers InstallFont","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shellex\\ContextMenuHandlers\\InstallFont\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shellex ContextMenuHandlers Open With","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shellex\\ContextMenuHandlers\\Open With\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shellex ContextMenuHandlers Open With EncryptionMenu","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shellex\\ContextMenuHandlers\\Open With EncryptionMenu\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx ContextMenuHandlers OpenContainingFolderMenu","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\ContextMenuHandlers\\OpenContainingFolderMenu\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"shellex ContextMenuHandlers PlayTo","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\shellex\\ContextMenuHandlers\\PlayTo\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx CopyHookHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\CopyHookHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx DragDropHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\DragDropHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx ExtShellFolderViews","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\ExtShellFolderViews\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEX IconHandler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\*\\ShellEX\\IconHandler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellEx PropertySheetHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\*\\ShellEx\\PropertySheetHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\InprocServer32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\InprocServer32\\Assembly","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID Instance CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\Instance\\**\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID Instance FriendlyName","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\Instance\\**\\FriendlyName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\LocalServer32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\LocalServer32\\Assembly","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\PersistentHandler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"CLSID TypeLib","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\CLSID\\*\\TypeLib\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"cmdfile shell open command","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\cmdfile\\shell\\open\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Directory background shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Directory\\background\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Directory shellex CopyHookHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Directory\\shellex\\CopyHookHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Directory shellex DragDropHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Directory\\shellex\\DragDropHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Directory shellex PropertySheetHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Directory\\shellex\\PropertySheetHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Drive shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Drive\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Classes Filter","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Filter\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Folder shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Folder\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Folder shellex DragDropHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Folder\\shellex\\DragDropHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Folder shellex PropertySheetHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Folder\\shellex\\PropertySheetHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"htmlfile shell open command","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\htmlfile\\shell\\open\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Interface ProxyStubClsid32","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Interface\\*\\ProxyStubClsid32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Interface TypeLib","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Interface\\*\\TypeLib\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Protocols Filter","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Protocols\\Filter\\*\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Protocols Handler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Protocols\\Handler\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Protocols Handler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Protocols\\Handler\\*\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Protocols Name-Space Handler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Protocols\\Name-Space Handler\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Protocols Name-Space Handler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Protocols\\Name-Space Handler\\*\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"SystemFileAssociations ShellEx ContextMenuHandlers ShellImagePreview","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\SystemFileAssociations\\*\\ShellEx\\ContextMenuHandlers\\ShellImagePreview\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"TypeLib win32","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\TypeLib\\*\\*\\*\\win32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"TypeLib win64","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\TypeLib\\*\\*\\*\\win64\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shell Open Command","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shell\\**\\DelegateExecute","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shell Runas command","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shell\\**\\IsolatedCommand","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx ColumnHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\ColumnHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx ContextMenuHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\ContextMenuHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shellex ContextMenuHandlers InstallFont","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\InstallFont\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shellex ContextMenuHandlers Open With","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\Open With\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shellex ContextMenuHandlers Open With EncryptionMenu","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\Open With EncryptionMenu\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx ContextMenuHandlers OpenContainingFolderMenu","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\ContextMenuHandlers\\OpenContainingFolderMenu\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 shellex ContextMenuHandlers PlayTo","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\PlayTo\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx CopyHookHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\CopyHookHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx DragDropHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\DragDropHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx ExtShellFolderViews","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\ExtShellFolderViews\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEX IconHandler","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEX\\IconHandler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellEx PropertySheetHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\*\\ShellEx\\PropertySheetHandlers\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\InprocServer32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\InprocServer32\\Assembly","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID Instance CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\Instance\\**\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID Instance FriendlyName","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\Instance\\**\\FriendlyName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\LocalServer32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\LocalServer32\\Assembly","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\PersistentHandler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 CLSID TypeLib","Category":"ASEP","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\CLSID\\*\\TypeLib\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Directory background shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Directory\\background\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Directory shellex CopyHookHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Directory\\shellex\\CopyHookHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Directory shellex DragDropHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Directory\\shellex\\DragDropHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Directory shellex PropertySheetHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Directory\\shellex\\PropertySheetHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Drive shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Drive\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Classes Filter","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Filter\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Folder shellex ContextMenuHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Folder\\shellex\\ContextMenuHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Folder shellex DragDropHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Folder\\shellex\\DragDropHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Folder shellex PropertySheetHandlers","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Folder\\shellex\\PropertySheetHandlers\\*\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Interface ProxyStubClsid32","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Interface\\*\\ProxyStubClsid32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Interface TypeLib","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\Interface\\*\\TypeLib\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 TypeLib win32","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\TypeLib\\*\\*\\*\\win32\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 TypeLib win64","Category":"ASEP Classes","Author":"Troy Larson","Glob":"Classes\\Wow6432Node\\TypeLib\\*\\*\\*\\win64\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"StartMenuInternet shell open command","Category":"ASEP","Author":"Troy Larson","Glob":"Clients\\StartMenuInternet\\*\\shell\\open\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"StartMenuInternet shell naom command","Category":"ASEP","Author":"Troy Larson","Glob":"Clients\\StartMenuInternet\\*\\shell\\naom\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"StartMenuInternet Shell RunAs Command","Category":"ASEP","Author":"Troy Larson","Glob":"Clients\\StartMenuInternet\\*\\Shell\\RunAs\\Command\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Chrome Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"Google\\Chrome\\Extensions\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Google Update","Category":"ASEP","Author":"Troy Larson","Glob":"Google\\Update\\path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":".NETFramework","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\.NETFramework\\DbgManagedDebugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Command Processor","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Command Processor\\autorun","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Cryptography Offload","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Cryptography\\Offload\\**\\ExpoOffload","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Ctf LangBarAddin","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Ctf\\LangBarAddin\\**\\Filepath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Approved Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Approved Extensions\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Explorer Bars","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Explorer Bars\\*\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Extension Validation","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Extension Validation\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Extensions\\**\\ClsidExtension","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Low Rights DragDrop","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Low Rights DragDrop","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppPath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Low Rights ElevationPolicy","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Low Rights ElevationPolicy","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppPath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Low Rights ElevationPolicy","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Plugins Extension","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Plugins\\Extension\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Toolbar","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Toolbar","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Toolbar ShellBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer Toolbar WebBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\Toolbar\\WebBrowser","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Explorer URLSearchHooks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Internet Explorer\\URLSearchHooks","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Office\\*\\Addins\\**\\Description","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Office\\*\\Addins\\**\\FriendlyName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Office\\*\\Addins\\**\\LoadBehavior","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Authentication Credential Provider Filters","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider Filters\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Authentication Credential Providers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Providers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Authentication PLAP Providers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Authentication\\PLAP Providers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer Browser Helper Objects","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer FindExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer FindExtensions Static","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\Static\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer SharedTaskScheduler","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer ShellExecuteHooks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellExecuteHooks\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer ShellIconOverlayIdentifiers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer ShellServiceObjects","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**\\autostart","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Ext PreApproved","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Ext\\PreApproved\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Group Policy Scripts Shutdown","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Shutdown\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Group Policy Scripts Startup","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Startup\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Internet Settings","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Explorer Run","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies System","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies System","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Policies\\System\\UIHost","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies System","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Userinit","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Run","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"RunOnce","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Runonce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"RunOnce Setup","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Runonce\\Setup","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"RunOnceEx","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\RunOnceEx","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"RunServices","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\RunServices","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"RunServicesOnce","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\RunServicesOnce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"SharedDLLs","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Shareddlls","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Shell Extensions Approved","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"ShellServiceObjectDelayLoad","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Installed SDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\InstallDate","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Installed SDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\DisplayName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\auto","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\Debugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\UserDebuggerHotKey","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags Custom","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseDescription","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseInstallTimeStamp","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabasePath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseType","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"AppCompatFlags Layers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\Current Version\\AppCompatFlags\\Layers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Drivers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Drivers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Drivers32","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Drivers32","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Font Drivers","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Font Drivers\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Image File Execution Options","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\GlobalFlag","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Image File Execution Options","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\Debugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Boot","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Boot\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Logon","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Logon\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Maintenance","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Maintenance\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Plain","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Plain\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Actions","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Author","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Description","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\DynamicInfo","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Hash","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Schema","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\SecurityDescriptor","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Source","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Triggers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\URI","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Version","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Schedule TaskCache Tree","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\**\\Id","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"SilentProcessExit","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\ReportingMode","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"SilentProcessExit","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\MonitorProcess","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Windows NT SvcHost","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\SvcHost\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Windows NT Terminal Server Run","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Windows NT Terminal Server Runonce","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Windows NT Terminal Server Runonceex","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonceex","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Microsoft Windows NT OsImagesFolder","Category":"ASEP","Author":"Troy Larson","Comment":"Looking for OsImagesFolder.","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\LayerRootLocations\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows NT CV Windows AppInitDlls","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows NT CV Windows IconServiceLib","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\IconServiceLib","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows NT CV Windows Load","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Windows NT CV Windows Run","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon GinaDLL","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Ginadll","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon Userinit","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon VMApplet","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMApplet","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon AppSetup","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AppSetup","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon Shell","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon System","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\System","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon Taskman","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Taskman","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon UIHost","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\UIHost","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon AlternateShells AvailableShells","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AlternateShells\\AvailableShells","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\DisplayName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\dllname","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Winlogon Notify","Category":"ASEP","Author":"Troy Larson","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify\\**\\dllname","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"MozillaPlugins","Category":"ASEP","Author":"Troy Larson","Glob":"MozillaPlugins\\*\\path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\**\\Script","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\**\\Script","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies Scripts Shutdown","Category":"ASEP","Author":"Troy Larson","Glob":"Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\**\\Script","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Policies Scripts Startup","Category":"ASEP","Author":"Troy Larson","Glob":"Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\**\\Script","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Google Update","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Google\\Update\\path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"WOW6432 .NETFramework","Category":"ASEP","Author":"Troy Larson","Glob":"WOW6432Node\\Microsoft\\.NETFramework\\DbgManagedDebugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"WOW6432 Command Processor Autorun","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Command Processor\\Autorun","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Ctf LangBarAddin","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Ctf\\LangBarAddin\\**\\Filepath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Approved Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Approved Extensions\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Explorer Bars","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Explorer Bars\\*\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Extension Validation","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Extension Validation\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Extensions\\**\\ClsidExtension","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Low Rights DragDrop","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Low Rights DragDrop","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppPath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Low Rights ElevationPolicy AppName","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Low Rights ElevationPolicy AppPath","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppPath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Low Rights ElevationPolicy CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\CLSID","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Plugins Extension","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Plugins\\Extension\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Toolbar","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Toolbar ShellBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE Toolbar WebBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar\\WebBrowser","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 IE URLSearchHooks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Internet Explorer\\URLSearchHooks","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\Description","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\FriendlyName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\LoadBehavior","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Authentication Credential Provider Filters","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider Filters\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Authentication Credential Providers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Providers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Authentication PLAP Providers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\PLAP Providers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer Browser Helper Objects","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer FindExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer FindExtensions Static","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\Static\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer SharedTaskScheduler","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer ShellExecuteHooks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellExecuteHooks\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer ShellIconOverlayIdentifiers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Explorer ShellServiceObjects","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**\\autostart","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Ext PreApproved","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Ext\\PreApproved\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Internet Settings","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Run","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 RunOnce","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Runonce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 RunOnce Setup","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Runonce\\Setup","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 RunOnceEx","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 RunServices","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunServices","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 RunServicesOnce","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunServicesOnce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 SharedDLLs","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Shareddlls","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Shell Extensions Approved","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 ShellServiceObjectDelayLoad","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Installed SDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\InstallDate","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Installed SDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\DisplayName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\auto","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\Debugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AeDebug","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\UserDebuggerHotKey","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseDescription","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseInstallTimeStamp","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabasePath","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AppCompatFlags InstalledSDB","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseType","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 AppCompatFlags Layers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\Current Version\\AppCompatFlags\\Layers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Drivers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Drivers32","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Font Drivers","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Font Drivers\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Image File Execution Options","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\GlobalFlag","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Image File Execution Options","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\Debugger","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Boot","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Boot\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Logon","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Logon\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Maintenance","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Maintenance\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Plain","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Plain\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Actions","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Author","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Description","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\DynamicInfo","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Hash","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Schema","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\SecurityDescriptor","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Source","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Triggers","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\URI","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tasks","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Version","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Schedule TaskCache Tree","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\**\\Id","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 SilentProcessExit","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\ReportingMode","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 SilentProcessExit","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\MonitorProcess","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT SvcHost","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SvcHost\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT Terminal Server Run","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT Terminal Server Runonce","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonce","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT Terminal Server Runonceex","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonceex","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT OsImagesFolder","Category":"ASEP","Author":"Troy Larson","Comment":"Looking for OsImagesFolder.","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\LayerRootLocations\\**","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Microsoft Windows NT CurrentVersion Windows","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Windows NT CV Windows IconServiceLib","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\IconServiceLib","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Windows NT CV Windows Load","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Windows NT CV Windows Run","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon GinaDLL","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Ginadll","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon Userinit","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon VMApplet","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMApplet","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon AppSetup","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AppSetup","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon Shell","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon System","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\System","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon Taskman","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Taskman","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon UIHost","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\UIHost","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon AlternateShells AvailableShells","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AlternateShells\\AvailableShells","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\@","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\DisplayName","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon GPExtensions","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\dllname","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 Winlogon Notify","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify\\**\\dllname","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Wow6432 MozillaPlugins","Category":"ASEP","Author":"Troy Larson","Glob":"Wow6432Node\\MozillaPlugins\\*\\path","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Desktop Wallpaper","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Control Panel\\DeskTop\\ConvertedWallpaper","Root":"HKEY_USERS"},{"Description":"Desktop Wallpaper","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Control Panel\\DeskTop\\OriginalWallpaper","Root":"HKEY_USERS"},{"Description":"Desktop Wallpaper","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Control Panel\\DeskTop\\WallPaper","Root":"HKEY_USERS"},{"Description":"Desktop Screensaver","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Control Panel\\DeskTop\\scrnsave.exe","Root":"HKEY_USERS"},{"Description":"Environment Logon Script","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Environment\\UserInitMprLogonScript","Root":"HKEY_USERS"},{"Description":"Chrome Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Google\\Chrome\\Extensions\\**\\path","Root":"HKEY_USERS"},{"Description":"Command Processor","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Command Processor\\autorun","Root":"HKEY_USERS"},{"Description":"Ctf LangBarAddin","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Ctf\\LangBarAddin","Root":"HKEY_USERS"},{"Description":"IE Approved Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Approved Extensions","Root":"HKEY_USERS"},{"Description":"IE DeskTop Components","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\DeskTop\\Components\\**","Root":"HKEY_USERS"},{"Description":"IE BackupWallpaper","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Desktop\\General\\BackupWallpaper","Root":"HKEY_USERS"},{"Description":"IE wallpapersource","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Desktop\\General\\wallpapersource","Root":"HKEY_USERS"},{"Description":"IE Explorer Bars","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Explorer Bars\\**","Root":"HKEY_USERS"},{"Description":"IE Extension Validation","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Extension Validation\\**","Root":"HKEY_USERS"},{"Description":"IE Extensions","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Extensions\\**","Root":"HKEY_USERS"},{"Description":"IE MenuExt","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\MenuExt\\**\\@","Root":"HKEY_USERS"},{"Description":"IE Toolbar ShellBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser","Root":"HKEY_USERS"},{"Description":"IE Toolbar WebBrowser","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\Toolbar\\WebBrowser","Root":"HKEY_USERS"},{"Description":"IE URLSearchHooks","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Internet Explorer\\URLSearchHooks","Root":"HKEY_USERS"},{"Description":"Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Office\\*\\Addins","Root":"HKEY_USERS"},{"Description":"Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Office\\*\\Addins\\*","Root":"HKEY_USERS"},{"Description":"Explorer Browser Helper Objects","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**","Root":"HKEY_USERS"},{"Description":"Explorer SharedTaskScheduler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler\\**","Root":"HKEY_USERS"},{"Description":"Explorer ShellIconOverlayIdentifiers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**","Root":"HKEY_USERS"},{"Description":"Explorer ShellServiceObjects","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**","Root":"HKEY_USERS"},{"Description":"Ext Settings","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Ext\\Settings\\**","Root":"HKEY_USERS"},{"Description":"Ext Stats","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Ext\\Stats\\**","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\DisplayName","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\ExecTime","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\FileSysPath","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\GPO-ID","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\IsPowershell","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\Parameters","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\PSScriptOrder","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\Script","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logoff","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\SOM-ID","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\DisplayName","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\ExecTime","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\FileSysPath","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\GPO-ID","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon*\\**\\IsPowershell","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\Parameters","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\PSScriptOrder","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\Script","Root":"HKEY_USERS"},{"Description":"Group Policy Scripts Logon","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\SOM-ID","Root":"HKEY_USERS"},{"Description":"Internet Settings AutoConfigProxy","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigProxy","Root":"HKEY_USERS"},{"Description":"Internet Settings AutoConfigURL","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL","Root":"HKEY_USERS"},{"Description":"Policies Explorer NoDriveTypeAutoRun","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\NoDriveTypeAutoRun","Root":"HKEY_USERS"},{"Description":"Policies Explorer Run","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run","Root":"HKEY_USERS"},{"Description":"Policies System Shell","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell","Root":"HKEY_USERS"},{"Description":"Policies System","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\UserInit","Root":"HKEY_USERS"},{"Description":"Run","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_USERS"},{"Description":"RunOnce","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce","Root":"HKEY_USERS"},{"Description":"RunOnceEx","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx","Root":"HKEY_USERS"},{"Description":"RunServices","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunServices","Root":"HKEY_USERS"},{"Description":"RunServicesOnce","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunServicesOnce","Root":"HKEY_USERS"},{"Description":"Shell Extensions Approved","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved\\**","Root":"HKEY_USERS"},{"Description":"ShellServiceObjectDelayLoad","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad\\**","Root":"HKEY_USERS"},{"Description":"Drivers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\drivers","Root":"HKEY_USERS"},{"Description":"Drivers32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\drivers32","Root":"HKEY_USERS"},{"Description":"Terminal Server Run","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_USERS"},{"Description":"Terminal Server RunOnce","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce","Root":"HKEY_USERS"},{"Description":"Terminal Server RunOnceEx","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx","Root":"HKEY_USERS"},{"Description":"Load","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load","Root":"HKEY_USERS"},{"Description":"Run","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run","Root":"HKEY_USERS"},{"Description":"Winlogon Shell","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell","Root":"HKEY_USERS"},{"Description":"Winlogon Userinit","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\userinit","Root":"HKEY_USERS"},{"Description":"Winlogon VMapplet","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMapplet","Root":"HKEY_USERS"},{"Description":"Mozilla Components, Extensions, \u0026 Plugins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Mozilla\\*\\Components\\**","Root":"HKEY_USERS"},{"Description":"Mozilla Components, Extensions, \u0026 Plugins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Mozilla\\*\\Extensions\\Components\\**","Root":"HKEY_USERS"},{"Description":"Mozilla Components, Extensions, \u0026 Plugins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Mozilla\\*\\Extensions\\Plugins\\**","Root":"HKEY_USERS"},{"Description":"Mozilla Components, Extensions, \u0026 Plugins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Mozilla\\*\\Plugins\\**","Root":"HKEY_USERS"},{"Description":"Mozilla Components, Extensions, \u0026 Plugins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\MozillaPlugins\\**","Root":"HKEY_USERS"},{"Description":"Policies Desktop Screensaver","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Policies\\Microsoft\\Windows\\Control Panel\\Desktop\\Scrnsave.exe","Root":"HKEY_USERS"},{"Description":"Policies Logoff Script","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\**\\Script","Root":"HKEY_USERS"},{"Description":"Policies Logon Script","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\**\\Script","Root":"HKEY_USERS"},{"Description":"Domain Profile Authorized Applications","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\AuthorizedApplications\\**","Root":"HKEY_USERS"},{"Description":"Standard Profile Authorized Applications","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Policies\\Microsoft\\WindowsFirewall\\StandardProfile\\AuthorizedApplications\\**","Root":"HKEY_USERS"},{"Description":"Wow6432 Command Processor","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Command Processor\\autorun","Root":"HKEY_USERS"},{"Description":"Wow6432 Internet Explorer Explorer Bars","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Internet Explorer\\Explorer Bars","Root":"HKEY_USERS"},{"Description":"Wow6432 Internet Explorer Extension","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Internet Explorer\\Extension","Root":"HKEY_USERS"},{"Description":"WOW6432Node Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Office\\*\\Addins","Root":"HKEY_USERS"},{"Description":"WOW6432Node Office Addins","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Office\\*\\Addins\\*","Root":"HKEY_USERS"},{"Description":"WOW6432Node Drivers32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32\\**","Root":"HKEY_USERS"},{"Description":"WOW6432Node Run","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run","Root":"HKEY_USERS"},{"Description":"WOW6432Node RunOnce","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnce","Root":"HKEY_USERS"},{"Description":".cmd","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes.cmd\\@","Root":"HKEY_USERS"},{"Description":".cmd PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes.cmd\\PersistentHandler\\@","Root":"HKEY_USERS"},{"Description":".exe","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes.exe\\@","Root":"HKEY_USERS"},{"Description":".exe PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes.exe\\PersistentHandler\\@","Root":"HKEY_USERS"},{"Description":"cmdfile","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classescmdfile\\@","Root":"HKEY_USERS"},{"Description":"exefile","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classesexefile\\@","Root":"HKEY_USERS"},{"Description":"Htmlfile Open","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesHtmlfile\\Shell\\Open\\Command\\@","Root":"HKEY_USERS"},{"Description":"ShellEx ColumnHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\ColumnHandlers\\@","Root":"HKEY_USERS"},{"Description":"ShellEx ContextMenuHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\ContextMenuHandlers\\@","Root":"HKEY_USERS"},{"Description":"ShellEx CopyHookHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\CopyHookHandlers\\@","Root":"HKEY_USERS"},{"Description":"ShellEx DragDropHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\DragDropHandlers\\@","Root":"HKEY_USERS"},{"Description":"ShellEx ExtShellFolderViews","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\ExtShellFolderViews\\@","Root":"HKEY_USERS"},{"Description":"ShellEx PropertySheetHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\Classes*\\ShellEx\\PropertySheetHandlers\\@","Root":"HKEY_USERS"},{"Description":"Directory Background ContextMenuHandlers","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesDirectory\\Background\\ShellEx\\ContextMenuHandlers\\@","Root":"HKEY_USERS"},{"Description":"CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\InprocServer32\\@","Root":"HKEY_USERS"},{"Description":"CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\InprocServer32\\Assembly","Root":"HKEY_USERS"},{"Description":"CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\LocalServer32\\@","Root":"HKEY_USERS"},{"Description":"CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\LocalServer32\\Assembly","Root":"HKEY_USERS"},{"Description":"CLSID PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\PersistentHandler","Root":"HKEY_USERS"},{"Description":"CLSID TypeLib","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\TypeLib\\@","Root":"HKEY_USERS"},{"Description":"CLSID Instance CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\Instance\\**\\CLSID","Root":"HKEY_USERS"},{"Description":"CLSID Instance FriendlyName","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesCLSID\\*\\Instance\\**\\FriendlyName","Root":"HKEY_USERS"},{"Description":"Interface ProxyStubClsid32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesInterface\\*\\ProxyStubClsid32\\@","Root":"HKEY_USERS"},{"Description":"Protocols CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesProtocols\\Filter\\*\\CLSID","Root":"HKEY_USERS"},{"Description":"Protocols Handler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesProtocols\\Handler\\*\\@","Root":"HKEY_USERS"},{"Description":"Protocols Handler CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesProtocols\\Handler\\*\\CLSID","Root":"HKEY_USERS"},{"Description":"Protocols Name-Space Handler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesProtocols\\Name-Space Handler\\*\\**\\@","Root":"HKEY_USERS"},{"Description":"ProtocolsName-Space Handler CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesProtocols\\Name-Space Handler\\*\\**\\CLSID","Root":"HKEY_USERS"},{"Description":"TypeLib","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesTypeLib\\*\\*\\@","Root":"HKEY_USERS"},{"Description":"TypeLib Win32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesTypeLib\\*\\*\\*\\win32\\**\\@","Root":"HKEY_USERS"},{"Description":"TypeLib Win64","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesTypeLib?*\\*\\*\\win64\\**\\@","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\InprocServer32\\@","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID InprocServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\InprocServer32\\Assembly","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\LocalServer32\\@","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID LocalServer32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\LocalServer32\\Assembly","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID PersistentHandler","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\PersistentHandler","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID TypeLib","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\TypeLib\\@","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID Instance CLSID","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\Instance\\**\\CLSID","Root":"HKEY_USERS"},{"Description":"Wow6432Node CLSID Instance FriendlyName","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\CLSID\\*\\Instance\\**\\FriendlyName","Root":"HKEY_USERS"},{"Description":"Wow6432Node Interface ProxyStubClsid32","Category":"ASEP","Author":"Troy Larson","Glob":"*\\Software\\ClassesWow6432Node\\Interface\\*\\ProxyStubClsid32\\@","Root":"HKEY_USERS"},{"Description":"Parse AmCache InventoryApplicationFile","Category":"ASEP","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl","Glob":"Root\\InventoryApplication*\\*","Root":"Amcache","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"Parse AmCache DriverBinary","Category":"ASEP","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl","Glob":"Root\\InventoryDriverBinary\\*","Root":"Amcache","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') + dict(Driver=OSPath.Basename)\n","Filter":"x=\u003eIsDir"},{"Description":"Parse AmCache InventoryApplicationShortcut","Category":"ASEP","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl","Glob":"Root\\InventoryApplicationShortcut\\*","Root":"Amcache","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"Active Setup Installed Components","Category":"ASEP","Glob":"Microsoft\\Active Setup\\Installed Components\\*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"Active Setup Installed Components","Category":"ASEP","Glob":"Wow6432Node\\Microsoft\\Active Setup\\Installed Components\\*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"AMSI Providers","Category":"System Info","Author":"M. Cohen","Reference":"https://pentestlab.blog/2021/05/17/persistence-amsi/\n","Comment":"The AMSI provider for Windows Defender seems to have been\nremoved/could not be found.\n\nAnalysis Tip: AMSI providers can be used for persistence.\n\nThe FeatureBit check determines if Authenicode signing is enabled or not.\n  0x01 - signing check is disabled; this is the default behavior (applies if value not found)\n  0x02 - signing check is enabled\n","Glob":"Microsoft\\AMSI\\Providers\\*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(\n  FeatureBits=GetValue(OSPath=OSPath + \"FeatureBits\"),\n  ProviderDll=GetProviderDllForGUID(GUID=OSPath.Basename))\n","Filter":"x=\u003etrue"},{"Description":"Adobe app cRecentFiles values","Category":"Third Party Applications","Glob":"*\\Software\\Adobe\\*\\*\\AVGeneral\\cRecentFiles\\*","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') +\n   dict(Version=OSPath[-4], Software=OSPath[-5],\n        sDI=CharsToString(X=GetValue(OSPath=OSPath + \"sDI\")),\n        sDate=CharsToString(X=GetValue(OSPath=OSPath + \"sDate\")))\n","Filter":"x=\u003etrue"},{"Description":"Adobe app cRecentFiles values","Category":"Third Party Applications","Glob":"*\\Software\\Adobe\\*\\*\\AVGeneral\\cRecentFolders\\*","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') +\n   dict(Version=OSPath[-4], Software=OSPath[-5],\n        sDI=CharsToString(X=GetValue(OSPath=OSPath + \"sDI\")),\n        sDate=CharsToString(X=GetValue(OSPath=OSPath + \"sDate\")))\n","Filter":"x=\u003etrue"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\MoSetup\\AllowUpgradesWithUnsupportedTPMOrCPU","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\LabConfig\\AllowUpgradesWithUnsupportedTPMOrCPU","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\MoSetup\\BypassRAMCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\LabConfig\\BypassRAMCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\MoSetup\\BypassTPMCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\LabConfig\\BypassTPMCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\MoSetup\\BypassSecureBootCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Check for Windows 11 requirement bypass values","Category":"System Info","Author":"M. Cohen","Reference":"https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e","Comment":"Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n","Glob":"Setup\\LabConfig\\BypassSecureBootCheck","Root":"HKEY_LOCAL_MACHINE\\System"},{"Description":"Gets user's AMSIEnable value","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amsienable.pl","Comment":"Analysis Tip: If the AmsiEnable value is 0, AMSI is disabled.\n","Glob":"*\\Software\\Microsoft\\Windows Script\\Settings\\AmsiEnable","Root":"HKEY_USERS"},{"Description":"Gets contents of user's ApplicationAssociationToasts key","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appassoc.pl","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\ApplicationAssociationToasts","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"Get entries from AppCertDlls key","Category":"ASEP","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appcertdlls.pl","Glob":"ControlSet*\\Control\\Session Manager\\AppCertDlls","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n","Filter":"x=\u003etrue"},{"Description":"Check services for AppEnvironment/AppEnvironmentExtra values","Category":"Third Party Applications","Author":"M. Cohen","Comment":"Analysis Tip: The AppEnvironment and AppEnvironmentExtra values\nallow a service to have access to environment variables that\noverride those set by the system at service startup. These values\nare used by svrany\\.exe and nssm\\.exe.  Nssm\\.exe makes use of the\nParameters\\\\AppExit subkey to determine actions to take upon exit,\nand can be used to specify specific actions based on the app's\nexit code.\n\nRef: https://nssm.cc/usage\n","Glob":"ControlSet*\\Services\\*\\Parameters\\AppEnvironment","Root":"HKEY_LOCAL_MACHINE\\System","Filter":"x=\u003etrue"},{"Description":"Check services for AppEnvironment/AppEnvironmentExtra values","Category":"Third Party Applications","Author":"M. Cohen","Comment":"Analysis Tip: The AppEnvironment and AppEnvironmentExtra values\nallow a service to have access to environment variables that\noverride those set by the system at service startup. These values\nare used by svrany\\.exe and nssm\\.exe.  Nssm\\.exe makes use of the\nParameters\\\\AppExit subkey to determine actions to take upon exit,\nand can be used to specify specific actions based on the app's\nexit code.\n\nRef: https://nssm.cc/usage\n","Glob":"ControlSet*\\Services\\*\\Parameters\\AppEnvironmentExtra","Root":"HKEY_LOCAL_MACHINE\\System","Filter":"x=\u003etrue"},{"Description":"Gets contents of AppInit_DLLs value","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_DLLs","Root":"HKEY_LOCAL_MACHINE\\Software","Filter":"x=\u003etrue"},{"Description":"Gets contents of AppInit_DLLs value","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\LoadAppInit_DLLs","Root":"HKEY_LOCAL_MACHINE\\Software","Filter":"x=\u003etrue"},{"Description":"Gets contents of AppInit_DLLs value","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Windows\\RequireSignedAppInit_DLLs","Root":"HKEY_LOCAL_MACHINE\\Software","Filter":"x=\u003etrue"},{"Description":"Extracts AppKeys entries","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appkeys.pl","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AppKey","Root":"HKEY_USERS","Details":"x=\u003eAppKeyExtract(OSPath=x.OSPath)\n","Filter":"x=\u003etrue"},{"Description":"Extracts AppKeys entries","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appkeys.pl","Glob":"Microsoft\\Windows\\CurrentVersion\\Explorer\\AppKey","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eAppKeyExtract(OSPath=x.OSPath)\n","Filter":"x=\u003etrue"},{"Description":"Gets contents of user's Applets key","Category":"System Info","Author":"M. Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets","Root":"HKEY_USERS","Details":"x=\u003edict(Regedit=dict(\n  LastKey=GetValue(OSPath=x.OSPath + \"Regedit/LastKey\"),\n  Favorites=FetchKeyValuesWithRegex(\n    OSPath=x.OSPath + \"Regedit/Favorites\", Regex='.')))\n","Filter":"x=\u003etrue"},{"Description":"Gets AppModelUnlock values","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appmodel.pl","Comment":"Analysis Tip: Misuse of MS Apps can be an infection vector (see\nref).  AllowAllTrustedApps = 1 allows loading of Apps not from the\nWindows Store (must have valid cert chain) (Enables sideloading)\n\nAllowDevelopmentWithoutDevLicense = 1 enables dev mode, allowing\ninstall of Apps from IDE, and allows users without\nSeCreateSymbolicLinkPrivilege to create symlinks.\n\nRef: https://www.sentinelone.com/labs/inside-malicious-windows-apps-for-malware-deployment/\nRef: https://twitter.com/0gtweet/status/1675583251161792512\n","Glob":"Microsoft\\Windows\\CurrentVersion\\AppModelUnlock","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath,\n   Regex='AllowAllTrustedApps|AllowDevelopmentWithoutDevLicense')\n","Filter":"x=\u003etrue"},{"Description":"Gets content of App Paths subkeys","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/apppaths.pl","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths","Root":"HKEY_USERS","Details":"x=\u003eGetAppPaths(OSPath=x.OSPath)\n","Filter":"x=\u003etrue","Preamble":["LET GetAppPaths(OSPath) = SELECT OSPath, Mtime, FetchKeyValues(OSPath=OSPath) AS App\n  FROM glob(root=OSPath, globs=\"*\", accessor=\"registry\")\n  WHERE IsDir\n"]},{"Description":"Gets content of App Paths subkeys","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/apppaths.pl","Glob":"Microsoft\\Windows\\CurrentVersion\\App Paths","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eGetAppPaths(OSPath=x.OSPath)\n","Filter":"x=\u003etrue","Preamble":["LET GetAppPaths(OSPath) = SELECT OSPath, Mtime, FetchKeyValues(OSPath=OSPath) AS App\n  FROM glob(root=OSPath, globs=\"*\", accessor=\"registry\")\n  WHERE IsDir\n"]},{"Description":"Get autolaunch entries for when user connects to Terminal Server","Category":"Persistence","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appsetup.pl","Comment":"Analysis Tip: The commands listed will be launched when the user\nconnects to a Terminal Server. The entries will be found in the\nsystem32 folder.\n","Glob":"Microsoft\\Windows NT\\CurrentVersion\\WinLogon\\AppSetup","Root":"HKEY_LOCAL_MACHINE\\Software"},{"Description":"Gets contents of user's Intellipoint\\\\AppSpecific subkeys","Category":"System Info","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appspecific.pl","Glob":"*\\Software\\Microsoft\\IntelliPoint\\AppSpecific\\*","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n"},{"Description":"Checks for persistence via Universal Windows Platform Apps","Category":"Persistence","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appx.pl\nhttps://oddvar.moe/2018/09/06/persistence-using-universal-windows-platform-apps-appx/\n","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\PackagedAppXDebug\\*","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n"},{"Description":"Checks for persistence via Universal Windows Platform Apps","Category":"Persistence","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appx.pl\nhttps://oddvar.moe/2018/09/06/persistence-using-universal-windows-platform-apps-appx/\n","Glob":"*\\Software\\Classes\\ActivatableClasses\\Package\\*\\DebugInformation\\*","Root":"HKEY_USERS","Details":"x=\u003edict(Application=x.OSPath[-1],\n        DebugPath=GetValue(OSPath=OSPath + \"DebugPath\"))\n","Filter":"x=\u003etrue"},{"Description":"Get shell open command settings for various file types","Category":"Persistence","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/assoc.pl\nhttps://cocomelonc.github.io/malware/2022/08/26/malware-pers-9.html\n","Comment":"Malware can persist by taking over the default actions when a user\ndouble-clicks a particular file type.\n","Glob":"Classes\\*\\shell\\open\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(Application=x.OSPath[3],\n        Key=OSPath,\n        Command=GetValue(OSPath=OSPath))\n"},{"Description":"Get shell open command settings for various file types","Category":"Persistence","Author":"M. Cohen","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/assoc.pl\nhttps://cocomelonc.github.io/malware/2022/08/26/malware-pers-9.html\n","Comment":"Malware can persist by taking over the default actions when a user\ndouble-clicks a particular file type.\n","Glob":"Classes\\*\\shell\\edit\\command\\@","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(Application=x.OSPath[3],\n        Key=OSPath,\n        Command=GetValue(OSPath=OSPath))\n"},{"Description":"Automount settings","Category":"System Info","Reference":"https://github.com/keydet89/RegRipper4.0/blob/main/plugins/automount.pl\n","Glob":"ControlSet*\\Services\\mountmgr","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003edict(\n    NoAutoMount=GetValue(OSPath=x.OSPath + \"NoAutoMount\"),\n    Automount=if(condition=GetValue(OSPath=x.OSPath + \"NoAutoMount\"),\n      then=\"Disabled\", else=\"Enabled\"))\n","Filter":"x=\u003etrue"},{"Description":"Interface Properties (IPv4)","Category":"System Info","Glob":"CurrentControl*\\Services\\Tcpip\\Parameters\\Interfaces\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AddressType|DhcpConnForceBroadcastFlag|DhcpDefaultGateway|DhcpDomain|DhcpDomainSearchList|DhcpGatewayHardware|DhcpGatewayHardwareCount|DhcpIPAddress|DhcpNameServer|DhcpServer|DhcpSubnetMask|DhcpSubnetMaskOpt|Domain|EnableDHCP|EnableMulticast|IPAddress|IsServerNapAware|Lease}LeaseObtainedTime|LeaseTerminatesTime|NameServer|RegisterAdapterName|RegistrationEnabled|SubnetMask|T1|T2\") + dict(\n   LeaseObtainedTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseObtainedTime\")),\n   LeaseTerminatesTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseTerminatesTime\")),\n   DhcpGatewayHardware=FormatMAC(x=GetValue(OSPath=x.OSPath + \"DhcpGatewayHardware\") || \"\"),\n   T1=timestamp(epoch=GetValue(OSPath=x.OSPath + \"T1\")),\n   T2=timestamp(epoch=GetValue(OSPath=x.OSPath + \"T2\"))\n)\n","Filter":"x=\u003eIsDir"},{"Description":"Interface Properties (IPv6)","Category":"System Info","Glob":"CurrentControl*\\Services\\Tcpip6\\Parameters\\Interfaces\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AddressType|DhcpConnForceBroadcastFlag|DhcpDefaultGateway|DhcpDomain|DhcpDomainSearchList|DhcpGatewayHardware|DhcpGatewayHardwareCount|DhcpIPAddress|DhcpNameServer|DhcpServer|DhcpSubnetMask|DhcpSubnetMaskOpt|Domain|EnableDHCP|EnableMulticast|IPAddress|IsServerNapAware|Lease}LeaseObtainedTime|LeaseTerminatesTime|NameServer|RegisterAdapterName|RegistrationEnabled|SubnetMask|T1|T2\") + dict(\n   LeaseObtainedTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseObtainedTime\")),\n   LeaseTerminatesTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseTerminatesTime\"))\n)\n","Filter":"x=\u003eIsDir"},{"Description":"Regedit.exe Last Run","Category":"Executables","Author":"Troyla","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit","Root":"HKEY_USERS","Details":"x=\u003ex.Mtime"},{"Description":"Regedit.exe Last Key Viewed","Category":"Executables","Author":"Troyla","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit\\LastKey","Root":"HKEY_USERS"},{"Description":"WinLogon: Displays the details of the last user logged in to this system","Category":"System Info","Glob":"Microsoft\\Windows NT\\CurrentVersion\\WinLogon","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AutoLogonSID|LastUsedUsername|AutoAdminLogon|DefaultUserName|DefaultPassword\") + dict(AllValues=FetchKeyValues(OSPath=x.OSPath))\n","Filter":"x=\u003etrue"},{"Description":"LogonUI: Displays the last logged on SAM user","Category":"System Info","Glob":"Microsoft\\Windows\\CurrentVersion\\Authentication\\LogonUI","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"LastLoggedOnUser|LastLoggedOnSAMUser|LastLoggedOnDisplayName|SelectedUserSID|LastLoggedOnUserSID\") + dict(AllValues=FetchKeyValues(OSPath=x.OSPath))\n","Filter":"x=\u003etrue"},{"Description":"System Info (Current)","Category":"System Info","Glob":"Microsoft\\Windows NT\\CurrentVersion","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"SystemRoot|RegisteredOwner|RegisteredOrganization|DisplayVersion|ComputerName|ProductName|InstallDate|InstallationType|CurrentMajorVersionNumber|EditionID|CurrentBuildNumber|CurrentBuild|CompositionEditionID|BuildLab\")\n","Filter":"x=\u003etrue"},{"Description":"System Info (Historical)","Category":"System Info","Glob":"Setup\\Source OS*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"SystemRoot|RegisteredOwner|RegisteredOrganization|DisplayVersion|ComputerName|ProductName|InstallDate|InstallationType|CurrentMajorVersionNumber|EditionID|CurrentBuildNumber|CurrentBuild|CompositionEditionID|BuildLab\")\n","Filter":"x=\u003eIsDir"},{"Description":"Firewall Rules","Category":"System Info","Glob":"ControlSet001\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eParseFirewallRule(X=x.Data) + dict(RuleName=x.OSPath.Basename)\n","Preamble":["LET _ParseFirewallRule(X) = to_dict(item={\n   SELECT split(string=_value, sep_string=\"=\")[0] AS _key,\n          split(string=_value, sep_string=\"=\")[1] AS _value\n   FROM foreach(row=split(string=X, sep_string='|'))\n   WHERE NOT _key =~ \"^v\"\n})\n\nLET ParseFirewallRule(X) = _ParseFirewallRule(X=X) +\n   dict(Protocol=ProtocolLookup(X=_ParseFirewallRule(X=X).Protocol))\n"]},{"Description":"Microphone","Category":"Devices","Glob":"Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(\n  LastUsedTimeStart=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStart\")),\n  LastUsedTimeStop=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStop\"))\n)\n","Filter":"x=\u003eIsDir"},{"Description":"Webcam","Category":"Devices","Glob":"Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\webcam\\**","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(\n  LastUsedTimeStart=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStart\")),\n  LastUsedTimeStop=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStop\"))\n)\n","Filter":"x=\u003eIsDir"},{"Description":"JumplistData: Displays last execution time of a program","Category":"Program Execution","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Search\\JumplistData\\*","Root":"HKEY_USERS","Details":"x=\u003edict(Program=x.OSPath.Basename, LastExecutionTime=FILETIME(t=x.Data))\n"},{"Description":"RunMRU: Tracks commands from the Run box in the Start menu, lower MRU # (Value Data3) = more recent","Category":"Program Execution","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRU(OSPath=x.OSPath).value,\n        All=FetchKeyValues(OSPath=x.OSPath))\n","Filter":"x=\u003eIsDir"},{"Description":"CIDSizeMRU","Category":"Program Execution","Author":"Andrew Rathbun","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\CIDSizeMRU","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir","Preamble":["LET MRUProfile \u003c= '''\n[[\"Header\", 0, [\n   [\"Array\", 0, \"Array\", {\n      \"count\": 500,\n      \"sentinel\": \"x=\u003eNOT x\",\n      \"type\": \"int32\"\n    }]\n]]]\n'''\n\nLET CalculateMRUEx(OSPath) = SELECT split(string=utf16(string=GetValue(OSPath=OSPath + str(str=_value))), sep='\\x00')[0] AS value\nFROM foreach(row=parse_binary(\n       profile=MRUProfile,\n       accessor=\"data\",\n       filename=GetValue(OSPath=OSPath + \"MRUListEx\") || \"\",\n       struct=\"Header\").Array)\nWHERE _value \u003e 0\n"]},{"Description":"Background Activity Moderator (BAM)","Category":"Program Execution","Author":"Andrew Rathbun","Glob":"ControlSet*\\Services\\BAM\\State\\UserSettings\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003edict(Programs=_BAMPrograms(Root=x.OSPath),\n        UserSID=x.OSPath.Basename,\n        Username=ResolveSID(SID=x.OSPath.Basename))\n","Filter":"x=\u003eIsDir","Preamble":["LET _BAMPrograms(Root) = SELECT OSPath.Basename AS Program,\n  timestamp(winfiletime=parse_binary(accessor=\"data\",\n      filename=Data.value, struct=\"uint64\")) AS Timestamp\nFROM glob(accessor=\"registry\", globs=\"*\", root=Root)\nWHERE NOT Program =~ \"^(Version|Sequence)\"\n"]},{"Description":"Desktop Activity Moderator (DAM)","Category":"Program Execution","Author":"Andrew Rathbun, Mike Cohen","Glob":"ControlSet*\\Services\\DAM\\State\\UserSettings\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003edict(Programs=_BAMPrograms(Root=x.OSPath),\n        UserSID=x.OSPath.Basename,\n        Username=ResolveSID(SID=x.OSPath.Basename))\n","Filter":"x=\u003eIsDir"},{"Description":"UserAssist: GUI-based programs launched from the desktop","Category":"Program Execution","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\*\\Count\\*","Root":"HKEY_USERS","Details":"x=\u003edict(Program=rot13(string=x.OSPath.Basename),\n        NumberOfExecutions=_ExtractUserAssist(OSPath=x.Data).NumberOfExecutions,\n        LastExecutionTime=_ExtractUserAssist(OSPath=x.Data).LastExecution)\n","Preamble":["LET userAssistProfile = '''\n  [\n    [\"Header\", 0, [\n      [\"NumberOfExecutions\", 4, \"uint32\"],\n      [\"LastExecution\", 60, \"WinFileTime\", {\"type\":\"uint64\"}]\n    ]]\n  ]\n'''\n\nLET _ExtractUserAssist(Data) = parse_binary(accessor=\"data\",\n                  filename=Data,\n                  profile=userAssistProfile, struct=\"Header\")\n"]},{"Description":"RADAR: Displays applications that were running at one point in time on this system","Category":"Program Execution","Author":"Andrew Rathbun, Mike Cohen","Glob":"Microsoft\\RADAR\\HeapLeakDetection\\DiagnosedApplications","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(Programs=_RADAR(OSPath=x.OSPath))\n","Filter":"x=\u003eIsDir","Preamble":["LET _RADAR(OSPath) = SELECT OSPath.Basename AS Program,\n   timestamp(winfiletime=GetValue(OSPath=OSPath + \"LastDetectionTime\")) AS LastDetectionTime\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"]},{"Description":"WordWheelQuery: User Searches","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\WordWheelQuery","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir"},{"Description":"OpenSavePidlMRU: Tracks files that have been opened or saved within a Windows shell dialog box","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\OpenSavePidlMRU","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir"},{"Description":"OpenSaveMRU: Tracks files that have been opened or saved within a Windows shell dialog box","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\OpenSaveMRU","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir"},{"Description":"LastVisitedPidlMRU: Tracks the specific executable used by an application to open the files documented in OpenSavePidlMRU","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\LastVisitedPidlMRU","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir"},{"Description":"RecentDocs: Files recently opened from Windows Explorer","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RecentDocs","Root":"HKEY_USERS","Details":"x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n","Filter":"x=\u003eIsDir"},{"Description":"Recent File List: Displays recent files accessed by the user with an application","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\*\\*\\Recent File List","Root":"HKEY_USERS","Details":"x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n","Filter":"x=\u003eIsDir","Preamble":["LET _RecentFileList(OSPath) = SELECT Data.value AS F\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\nWHERE OSPath.Basename =~ \"File\"\n"]},{"Description":"Recent Folder List: Displays recent folders accessed by the user with an application","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\*\\*\\Recent Folder List","Root":"HKEY_USERS","Details":"x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n","Filter":"x=\u003eIsDir"},{"Description":"Recent Document List: Displays recent Documents accessed by the user with an application","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\*\\*\\Settings\\Recent Document List","Root":"HKEY_USERS","Details":"x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n","Filter":"x=\u003eIsDir"},{"Description":"Recent","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\*\\*\\Recent","Root":"HKEY_USERS","Details":"x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n","Filter":"x=\u003eIsDir"},{"Description":"RecentFind","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\*\\*\\RecentFind","Root":"HKEY_USERS","Details":"x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n","Filter":"x=\u003eIsDir"},{"Description":"User Shell Folders: Displays where a user's Shell folders are mapped to","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)\n","Filter":"x=\u003eIsDir"},{"Description":"FeatureUsage: Displays the number of times the user has received a notification for an application","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FeatureUsage","Root":"HKEY_USERS","Details":"x=\u003edict(AppBadgeUpdated= _FeatureUsage(OSPath=x.OSPath + \"AppBadgeUpdated\"),\n        AppLaunch=_FeatureUsage(OSPath=x.OSPath + \"AppLaunch\"),\n        AppSwitched=_FeatureUsage(OSPath=x.OSPath + \"AppSwitched\"),\n        ShowJumpView=_FeatureUsage(OSPath=x.OSPath + \"ShowJumpView\"),\n        TrayButtonClicked=FetchKeyValues(OSPath=x.OSPath + \"TrayButtonClicked\"))\n","Filter":"x=\u003eIsDir","Preamble":["LET _FeatureUsage(OSPath) = SELECT OSPath.Basename AS Application,\n    Data.value AS Number\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"]},{"Description":"Terminal Server Client (RDP): Displays the IP addresses/hostnames of devices this system has connected to (Outbound RDP)","Category":"User Activity","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Terminal Server Client","Root":"HKEY_USERS","Details":"x=\u003edict(\n DefaultMRU=RDPMRU(OSPath=OSPath).Server,\n Servers={\n  SELECT OSPath.Basename AS Server, Mtime,\n    FetchKeyValues(OSPath=OSPath) AS Details\n  FROM glob(accessor=\"registry\", globs='*', root=OSPath + \"Servers\")\n})\n","Filter":"x=\u003eIsDir","Preamble":["LET RDPMRU(OSPath) = SELECT Data.value AS Server\nFROM glob(accessor=\"registry\", globs='*', root=OSPath + \"Default\")\nWHERE OSPath.Basename =~ \"MRU\"\n"]},{"Description":"Run (Group Policy)","Category":"Autoruns","Author":"Andrew Rathbun, Mike Cohen","Glob":"Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)\n","Filter":"x=\u003eIsDir AND Details"},{"Description":"Run (NTUSER)","Category":"Autoruns","Author":"Andrew Rathbun, Mike Cohen","Glob":"*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run*","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)\n","Filter":"x=\u003eIsDir AND Details"},{"Description":"Run (SYSTEM)","Category":"Autoruns","Author":"Andrew Rathbun, Mike Cohen","Glob":"Microsoft\\Windows\\CurrentVersion\\Run*","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)\n","Filter":"x=\u003eIsDir AND Details"},{"Description":"Scheduled Tasks (TaskCache)","Category":"Autoruns","Author":"Andrew Rathbun, Mike Cohen","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(Tasks= _TaskCache(OSPath=x.OSPath))\n","Filter":"x=\u003eIsDir AND Details","Preamble":["LET _ParseActions(Data)  = parse_binary(accessor=\"data\",\n            filename=Data, struct=\"Header\",\n            profile='''\n[[\"Header\", 0, [\n [\"__Ver\", 0, \"uint16\"],\n [\"__UserLen\", 2, \"uint32\"],\n [\"User\", 6, \"String\", {length: \"x=\u003ex.__UserLen\", encoding: \"utf16\"}],\n [\"__ActionType\", \"x=\u003e6 + x.__UserLen\", \"uint16\"],\n [\"ActionType\", \"x=\u003e6 + x.__UserLen\", \"Enumeration\", {\n    type: \"uint32\",\n    choices: {\n      \"26214\": \"BinaryAction\",\n      \"30583\": \"ComHanlder\",\n      \"34952\": \"Email\",\n      \"39321\": \"MessageBox\",\n    }\n }],\n [\"Action\", \"x=\u003e6 + x.__UserLen + 2\", \"Union\", {\n   selector: \"x=\u003ex.__ActionType\",\n   choices: {\n     \"26214\": BinaryAction,\n     \"30583\": ComHandler,\n   }\n }],\n]],\n[\"ComHandler\", 0, [\n [\"ClassID\", 4, \"GUID\"],\n [\"__DataLen\", 20, uint32],\n [\"Data\", 24, \"String\", {\n   \"length\": \"x=\u003ex.__DataLen\",\n   \"encoding\": \"utf16\",\n }]\n]],\n[\"GUID\", 16, [\n [\"__D1\", 0, \"uint32\"],\n [\"__D2\", 4, \"uint16\"],\n [\"__D3\", 6, \"uint16\"],\n [\"__D4\", 8, \"String\", {\"term\": \"\", \"length\": 2}],\n [\"__D5\", 10, \"String\", {\"term\": \"\", \"length\": 6}],\n [\"Value\", 0, \"Value\", {\n    \"value\": \"x=\u003eformat(format='{%08x-%04x-%04x-%02x-%02x}', args=[x.__D1, x.__D2, x.__D3, x.__D4, x.__D5])\"\n}]\n]],\n[\"BinaryAction\", 0, [\n [\"__BinLen\", 4, \"uint32\"],\n [\"Binary\", 8, \"String\", {length: \"x=\u003ex.__BinLen\", encoding: \"utf16\"}],\n]]]\n''')\n\nLET _ParseDynamicInfo(Data) = parse_binary(accessor=\"data\",\n            filename=Data, struct=\"Header\",\n            profile='''\n[[\"Header\", 0, [\n [\"__Ver\", 0, \"uint16\"],\n [\"Created\", 4, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"LastStart\", 12, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"LastStop\", 20, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"TaskState\", 28, \"uint32\"],\n [\"LastErrorCode\", 32, \"uint32\"],\n [\"LastSuccessfulRun\", 36, \"WinFileTime\", {\"type\": \"uint64\"}],\n]]]\n''')\n\nLET _TaskCache(OSPath) = SELECT to_dict(item={\n  SELECT OSPath.Basename AS _key,\n    if(condition= OSPath.Basename =~ \"DynamicInfo\",\n       then=_ParseDynamicInfo(Data=Data.value),\n    else= if(condition= OSPath.Basename =~ \"Actions\",\n       then=_ParseActions(Data=Data.value),\n    else=Data.value)) AS _value\n  FROM glob(accessor=\"registry\", globs='*', root=OSPath)\n}) + dict(OSPath=OSPath) AS Details\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"]},{"Description":"Services: Displays list of services running on this computer","Category":"Services","Author":"Andrew Rathbun, Mike Cohen","Glob":"ControlSet*\\Services\\*","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003e_ServicesInfo(OSPath=x.OSPath)\n","Filter":"x=\u003eIsDir","Preamble":["LET _ServiceTypeLookup \u003c= dict(`1`=\"KernelDriver\", `2`=\"FileSystemDriver\", `4`=\"Adapter\", `8`=\"RecognizerDriver\", `16`=\"Win32OwnProcess\", `32`=\"Win32ShareProcess\", `256`=\"InteractiveProcess\", `96`=\"Win32ShareProcess\")\nLET _ServiceStartModeLookup \u003c= dict(`0`=\"Boot\", `1`=\"System\", `2`=\"Automatic\", `3`=\"Manual\", `4`=\"Disabled\")\n\nLET _ServicesInfo(OSPath) =\n    FetchKeyValuesWithRegex(OSPath=OSPath, Regex=\"Description|DisplayName|ServiceDll|Group|ImagePath|RequiredPrivileges|Type|Parameters|SERVICEDLL\") +\n    dict(Mtime=Mtime, Service=OSPath.Basename,\n         TypeName=get(item=_ServiceTypeLookup, field=str(str=GetValue(OSPath=OSPath + \"Type\"))),\n         StartName=get(item=_ServiceStartModeLookup, field=str(str=GetValue(OSPath=OSPath + \"Start\")))\n    )\n"]},{"Description":"Environment Variables","Category":"System Info","Glob":"ControlSet*\\Control\\Session Manager\\Environment","Root":"HKEY_LOCAL_MACHINE\\System","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)","Filter":"x=\u003eIsDir"},{"Description":"Environment Variables","Category":"System Info","Glob":"*\\Environment","Root":"HKEY_USERS","Details":"x=\u003eFetchKeyValues(OSPath=x.OSPath)","Filter":"x=\u003eIsDir"},{"Description":"Exploit Guards MitigationOptions","Category":"System Info","Author":"@bmcdermott-r7 Blake McDermott","Reference":"https://theryuu.github.io/ifeo-mitigationoptions.txt\n","Comment":"Parses Exploit Guards MitigationOptions to see what security\ncontrols are enabled for each process, and returns them in a 15\ndigit hexidecimal value.\n","Glob":"Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\MitigationOptions","Root":"HKEY_LOCAL_MACHINE\\Software","Details":"x=\u003edict(ProcName=x.OSPath[-2],\n        DecValue=x.Data,\n        HexValue=format(format=\"%#015x\", args=x.Data),\n        Parsed=ParseMitigationOptions(H=format(format=\"%#015x\", args=x.Data)))\n","Preamble":["LET ParseMitigationOptions(H) = RemoveNullDictValue(D=dict(\n DEP=\n   (H[-1:] = \"1\" \u0026\u0026 \"Always On\") ||\n   (H[-1:] = \"2\" \u0026\u0026 \"Always On - enable ATL thunk emulation\"),\n SEHOP=(H[-2:-1] = \"1\"),\n ASLR=\n    (H[-3:-2] = \"1\" \u0026\u0026 \"Enable force relocate.\") ||\n    (H[-3:-2] = \"2\" \u0026\u0026 \"Force relocate off.\") ||\n    (H[-3:-2] = \"3\" \u0026\u0026 \"Force relocate always on.\"),\n `Heap terminate`=\n    (H[-4:-3] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-4:-3] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Bottom ASLR`=\n    (H[-5:-4] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-5:-4] = \"2\" \u0026\u0026 \"Always Off.\"),\n `HEASLR`=\n    (H[-6:-5] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-6:-5] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Strict handle checks`=\n    (H[-7:-6] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-7:-6] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Win32k system call disable policy`=\n    (H[-8:-7] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-8:-7] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Extension point disable policy`=\n    (H[-9:-8] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-9:-8] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Dynamic code policy (probably).`=\n    (H[-10:-9] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-10:-9] = \"2\" \u0026\u0026 \"Always Off.\") ||\n    (H[-10:-9] = \"3\" \u0026\u0026 \"Always On with optout.\"),\n `Control Flow Guard (CFG)`=\n    (H[-11:-10] = \"1\" \u0026\u0026 \"Enable\") ||\n    (H[-11:-10] = \"2\" \u0026\u0026 \"Disable\"),\n `Binary signature policy.`=\n    (H[-12:-11] = \"1\" \u0026\u0026 \"Microsoft signed only.\") ||\n    (H[-12:-11] = \"2\" \u0026\u0026 \"Disable?\"),\n `Font loading prevention.`=\n    (H[-13:-12] = \"1\" \u0026\u0026 \"Enable\") ||\n    (H[-13:-12] = \"2\" \u0026\u0026 \"Disable\") ||\n    (H[-13:-12] = \"3\" \u0026\u0026 \"Enable with Audit\"),\n `Image load policy (remote images).`=\n    (H[-14:-13] = \"1\" \u0026\u0026 \"Always On\") ||\n    (H[-14:-13] = \"2\" \u0026\u0026 \"Always Off\") ||\n    (H[-14:-13] = \"3\" \u0026\u0026 \"Reserved\"),\n `Image load policy (low mandatory label).`=\n    (H[-15:-14] = \"1\" \u0026\u0026 \"Always On\") ||\n    (H[-15:-14] = \"2\" \u0026\u0026 \"Always Off\") ||\n    (H[-15:-14] = \"3\" \u0026\u0026 \"Reserved\")))\n"]}]
+[
+  {
+   "Description": "AppCompatCache: AKA ShimCache, data is only written to this value at reboot by winlogon.exe",
+   "Category": "Program Execution",
+   "Glob": "ControlSet*\\Control\\Session Manager\\AppCompatCache\\AppCompatCache",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eAppCompatCache(Blob=read_file(accessor=\"registry\", filename=OSPath))\n",
+   "Filter": "x=\u003etrue",
+   "Preamble": [
+    "LET AppCompatCacheParser \u003c= '''[\n[\"HeaderWin10\", \"x=\u003ex.HeaderSize\", [\n  [\"HeaderSize\", 0, \"unsigned int\"],\n  [\"Entries\", \"x=\u003ex.HeaderSize\", Array, {\n      type: \"Entry\",\n      sentinel: \"x=\u003ex.Size = 0\",\n      count: 10000,\n      max_count: 10000,\n  }]\n]],\n[\"HeaderWin8\", 128, [\n  [\"Entries\", 128, Array, {\n      type: \"EntryWin8\",\n      sentinel: \"x=\u003ex.EntrySize = 0\",\n      count: 10000,\n      max_count: 10000,\n  }]\n]],\n\n[\"EntryWin8\", \"x=\u003ex.EntrySize + 12\", [\n  [\"Signature\", 0, \"String\", {\n     length: 4,\n  }],\n  [\"EntrySize\", 8, \"unsigned int\"],\n  [\"PathSize\", 12, \"uint16\"],\n  [\"Path\", 14, \"String\", {\n      length: \"x=\u003ex.PathSize\",\n      encoding: \"utf16\",\n  }],\n  [\"LastMod\", \"x=\u003ex.PathSize + 14 + 10\", \"WinFileTime\"]\n]],\n\n[\"Entry\", \"x=\u003ex.Size + 12\", [\n  [\"Signature\", 0, \"String\", {\n     length: 4,\n  }],\n  [\"Size\", 8, \"unsigned int\"],\n  [\"PathSize\", 12, \"uint16\"],\n  [\"Path\", 14, \"String\", {\n      length: \"x=\u003ex.PathSize\",\n      encoding: \"utf16\",\n  }],\n  [\"LastMod\", \"x=\u003ex.PathSize + 14\", \"WinFileTime\"],\n  [\"DataSize\", \"x=\u003ex.PathSize + 14 + 8\", \"uint32\"],\n  [\"Data\", \"x=\u003ex.PathSize + 14 + 8 + 4\" , \"String\", {\n      length: \"x=\u003ex.DataSize\",\n  }],\n\n  # The last byte of the Data block is 1 for execution\n  [\"Execution\", \"x=\u003ex.PathSize + 14 + 8 + 4 + x.DataSize - 4\", \"uint32\"]\n]],\n\n# This is the Win7 parser but we dont use it right now.\n[\"HeaderWin7x64\", 128, [\n  [\"Signature\", 0, \"uint32\"],\n  [\"Entries\", 128, \"Array\", {\n      count: 10000,\n      sentinel: \"x=\u003ex.PathSize = 0\",\n      type: EntryWin7x64,\n  }]\n]],\n[\"EntryWin7x64\", 48, [\n  [\"PathSize\", 0, \"uint16\"],\n  [\"PathOffset\", 8, \"uint32\"],\n  [\"Path\", \"x=\u003ex.PathOffset - x.StartOf\", \"String\", {\n      encoding: \"utf16\",\n      length: \"x=\u003ex.PathSize\",\n  }],\n  [\"LastMod\", 16, \"WinFileTime\"]\n]]\n\n]'''\n\nLET AppCompatCacheWin10(Blob) = parse_binary(\n    accessor=\"data\",\n    filename=Blob,\n    profile=AppCompatCacheParser,\n    struct=\"HeaderWin10\")\n\nLET AppCompatCacheWin8(Blob) = parse_binary(\n    accessor=\"data\",\n    filename=Blob,\n    profile=AppCompatCacheParser,\n    struct=\"HeaderWin8\")\n\nLET AppCompatCache(Blob) = SELECT LastMod, Path, Execution\nFROM foreach(\n  row=if(\n    condition=AppCompatCacheWin10(Blob=Blob).HeaderSize IN (52, 48),\n    then=AppCompatCacheWin10(Blob=Blob).Entries,\n    else=AppCompatCacheWin8(Blob=Blob).Entries))\n"
+   ]
+  },
+  {
+   "Description": "AppCompatFlags: Displays programs that are configured to run in Compatibility Mode in Windows",
+   "Category": "Program Execution",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Programs=AppCompatFlagsPrograms(OSPath=x.OSPath).Program)\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET AppCompatFlagsPrograms(OSPath) = SELECT OSPath.Basename AS Program\n   FROM glob(globs='Compatibility Assistant/{Store,Persisted}/*',\n             accessor=\"registry\", root=OSPath)\n"
+   ]
+  },
+  {
+   "Description": "Rclone",
+   "Category": "Threat Hunting",
+   "Author": "BusterBaxter5",
+   "Comment": "We detect both the config file and registry artifacts from AppCompatFlags",
+   "Glob": "",
+   "Root": "",
+   "Query": "SELECT * FROM chain(a={\n  SELECT Description, Category, OSPath, Mtime,\n       dict(Uploaded=upload(file=OSPath), Type=\"Config File\") AS Details\n  FROM glob(globs=\"C:\\\\Users\\\\*\\\\AppData\\\\Roaming\\\\rclone\\\\rclone.conf\")\n}, b={\n  SELECT Description, Category, OSPath, Mtime,\n       dict(Path=OSPath.Basename, Data=Data.value) AS Details\n  FROM glob(accessor=\"registry\",\n            globs=\"HKEY_USERS\\\\*\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\AppCompatFlags\\\\Compatibility Assistant\\\\Store\\\\*rclone*\")\n})\n"
+  },
+  {
+   "Description": "DotNetStartupHooks",
+   "Category": "Threat Hunting",
+   "Author": "Chris Jones - CPIRT | FabFaeb | Antonio Blescia (TheThMando) | bmcder02",
+   "Comment": "The .NET DLLs listed in the DOTNET_STARTUP_HOOKS environment\nvariable are loaded into .NET processes at runtime.\n",
+   "Glob": "",
+   "Root": "",
+   "Query": "SELECT OSPath, Data.value AS Value\nFROM glob(globs=[\n'''HKEY_LOCAL_MACHINE\\System\\ControlSet*\\Control\\Session Manager\\Environment\\DOTNET_STARTUP_HOOKS''',\n'''HKEY_USERS\\*\\Environment\\DOTNET_STARTUP_HOOKS'''], accessor=\"registry\")\nWHERE Value\n"
+  },
+  {
+   "Description": "Windows Boot Volume",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Identifies the system volume where Windows booted from",
+   "Glob": "Setup\\SystemPartition",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "ControlSet Configuration",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays value for the current ControlSet",
+   "Glob": "Select\\Current",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "ControlSet Configuration",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays value for the default ControlSet",
+   "Glob": "Select\\Default",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "ControlSet Configuration",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays value for the ControlSet that was unable to boot Windows successfully",
+   "Glob": "Select\\Failed",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "ControlSet Configuration",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays value for the last known good ControlSet",
+   "Glob": "Select\\LastKnownGood",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Shutdown Time",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Last system shutdown time",
+   "Glob": "ControlSet00*\\Control\\Windows\\ShutdownTime",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFILETIME(t=x.Data)"
+  },
+  {
+   "Description": "Windows OS Language",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Default OS Language, 0409 is English",
+   "Glob": "ControlSet*\\Control\\Nls\\Language\\InstallLanguage",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Virtual Memory Pagefile Encryption Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Virtual Memory Pagefile Encryption, 0 = Disabled, 1 = Enabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\NtfsEncryptPagingFile",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "TRIM Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "TRIM, 0 = Enabled, 1 = Disabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\DisableDeleteNotification",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "NTFS File Compression Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "NTFS File Compression, 0 = Enabled, 1 = Disabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\NtfsDisableCompression",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "NTFS File Encryption Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "NTFS File Encryption, 0 = Enabled, 1 = Disabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\NtfsDisableEncryption",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "NTFS LastAccess Timestamp Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "NTFS LastAccess Timestamp, 2147483650 = Enabled, 1 = Disabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\NtfsDisableLastAccessUpdate",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Long Paths Enabled",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "NTFS Long Paths, 0 = Disabled, 1 = Enabled",
+   "Glob": "ControlSet*\\Control\\FileSystem\\LongPathsEnabled",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Prefetch Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Disabled, 1 = Application Prefetching Enabled, 2 = Boot Prefetching Enabled, 3 = Application and Boot Prefetching Enabled",
+   "Glob": "ControlSet00*\\Control\\Session Manager\\Memory Management\\PrefetchParameters\\EnablePrefetcher",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Clear Page File at Shutdown Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Disabled, 1 = Enabled",
+   "Glob": "ControlSet00*\\Control\\Session Manager\\Memory Management\\ClearPageFileAtShutdown",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "System Time Zone Information",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the current Time Zone configuration for this system",
+   "Glob": "ControlSet00*\\Control\\TimeZoneInformation",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Network Connections",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of network connections",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\NetworkList",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(\n   Profiles={\n     SELECT ProfileName, Description, Managed,\n            Category, CategoryType, GetDateFrom128Bit(x= DateCreated) AS DateCreated,\n            GetDateFrom128Bit(x=DateLastConnected) AS DateLastConnected\n     FROM read_reg_key(root=x.OSPath, globs=\"Profiles/*\")\n  },\n   Signatures={\n     SELECT Key.OSPath[-2:] AS Key,\n            FormatMAC(x=DefaultGatewayMac) AS DefaultGatewayMac,\n            DnsSuffix, ProfileGuid,\n            FirstNetwork\n     FROM read_reg_key(root=x.OSPath,\n          globs=\"/Signatures/*/*\")\n  }\n)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Device Classes",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of PnP devices (Plug and Play) that were connected to this system",
+   "Glob": "ControlSet*\\Control\\DeviceClasses\\*\\##*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eparse_string_with_regex(string=x.OSPath.Basename,\n     regex=\"##\\\\?#(?P\u003cType\u003e[^#]+)#(?P\u003cName\u003e[^#]+)#(?P\u003cserialNumber\u003e[^#]+)#(?P\u003cClass\u003e.+)\")\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "System Info (Current)",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Current OS install time",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\InstallTime",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFILETIME(t=x.Data)"
+  },
+  {
+   "Description": "Network Adapters",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of network adapters connected to this system",
+   "Glob": "ControlSet*\\Control\\Class\\?4d36e972-e325-11ce-bfc1-08002be10318?\\00*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n  InstallTimeStamp=GetDateFrom128Bit(x=GetValue(OSPath=x.OSPath + \"InstallTimeStamp\")),\n  NetworkInterfaceInstallTimestamp=FILETIME(t=GetValue(OSPath=x.OSPath + \"NetworkInterfaceInstallTimestamp\"))\n)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Windows 10 Timeline Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows 10 Activity Timeline status, 0 = Disabled, 1 = Enabled",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\EnableActivityFeed",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows 10 Timeline Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows 10 Activity Timeline status, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\PolicyManager\\default\\Privacy\\EnableActivityFeed\\value",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Clipboard History Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Clipboard History, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\PolicyManager\\default\\Privacy\\EnableClipboardHistory",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Clipboard History Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Clipboard Sync Across Devices, 0 = Disabled, 1 = Enabled",
+   "Glob": "Software\\Policies\\Microsoft\\Windows\\System\\AllowCrossDeviceClipboard",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Clipboard History Status",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Clipboard Sync Across Devices, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\PolicyManager\\default\\Privacy\\AllowCrossDeviceClipboard\\value",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "User Access Logging (SUM DB)",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the updating interval for the SUM DB. Default is 24 hours. 60000 = 60 seconds, for example",
+   "Glob": "ControlSet*\\Control\\WMI\\Autologger\\SUM\\PollingInterval",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "MAC Addresses",
+   "Category": "System Info",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays MAC Addresses related to this system. This key normally gets Permission Denied when using the API - use Raw Hives to access",
+   "Glob": "ControlSet00*\\Control\\NetworkSetup2\\Interfaces\\*\\Kernel",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n   PermanentAddress=FormatMAC(x=GetValue(OSPath=x.OSPath + \"PermanentAddress\") || \"\"),\n   CurrentAddress=FormatMAC(x=GetValue(OSPath=x.OSPath + \"CurrentAddress\") || \"\")\n)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Bluetooth Devices",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the Bluetooth devices that have been connected to this computer",
+   "Glob": "ControlSet*\\Services\\BTHPORT\\Parameters\\Devices\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Volume Info Cache",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "2 = Removable, 3 = Fixed, 4 = Network, 5 = Optical, 6 = RAM disk, 0 = Unknown",
+   "Glob": "Microsoft\\Windows Search\\VolumeInfoCache\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath) + dict(\n   DriveName=x.OSPath.Basename,\n   DriveType=ExtractValueFromComment(x=GetValue(OSPath=x.OSPath + \"DriveType\"))\n)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "USBSTOR",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of USB devices that have been plugged into this system. If \u0026 is second character within serial number, serial number is only unique on the system",
+   "Glob": "ControlSet*\\Enum\\USBSTOR\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003edict(\n  Name=x.OSPath.Basename,\n  Manufacturer=split(string=x.OSPath.Basename, sep=\"\u0026\")[1],\n  Title=split(string=x.OSPath.Basename, sep=\"\u0026\")[2],\n  Version=split(string=x.OSPath.Basename, sep=\"\u0026\")[3],\n  Instance={\n    SELECT OSPath.Basename AS Serial, dict(\n       DeviceName=utf16(string=GetRawValue(OSPath=OSPath + \"/Properties/{540b947e-8b40-45bc-a8a2-6a0b894cbda2}/0004/@\")),\n       Installed=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0064/@\")),\n       FirstInstalled=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0065/@\")),\n       LastConnected=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0066/@\")),\n       LastRemoved=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0067/@\"))\n    ) AS Properties,\n    to_dict(item={\n       SELECT OSPath.Basename AS _key, Data.value AS _value\n       FROM glob(globs=\"*\", accessor=\"registry\", root=OSPath)\n    }) AS Metadata\n    FROM glob(globs='*', root=x.OSPath, accessor=\"raw_registry\")\n  }\n)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "USB",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Provides VID and PID numbers of USB devices. Match serial number from USBSTOR and search for VID and PID across the system",
+   "Glob": "ControlSet*\\Enum\\USB\\VID_*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003edict(\n  Name=x.OSPath.Basename,\n  Vid=split(string=x.OSPath.Basename, sep=\"\u0026\")[0],\n  Pid=split(string=x.OSPath.Basename, sep=\"\u0026\")[1],\n  Instance={\n    SELECT OSPath.Basename AS Serial, dict(\n       DeviceName=utf16(string=GetRawValue(OSPath=OSPath + \"/Properties/{540b947e-8b40-45bc-a8a2-6a0b894cbda2}/0004/@\")),\n       Installed=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0064/@\")),\n       FirstInstalled=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0065/@\")),\n       LastConnected=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0066/@\")),\n       LastRemoved=FILETIME(t=GetRawValue(OSPath=OSPath + \"/Properties/{83da6326-97a6-4088-9453-a1923f573b29}/0067/@\"))\n    ) AS Properties,\n    to_dict(item={\n       SELECT OSPath.Basename AS _key, Data.value AS _value\n       FROM glob(globs=\"*\", accessor=\"registry\", root=OSPath)\n    }) AS Metadata\n    FROM glob(globs='*', root=x.OSPath, accessor=\"raw_registry\")\n  }\n)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "MountPoints2",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Mount Points - NTUSER",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\MountPoints2\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mounted Devices",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Last Write Timestamp is for entire key, not each individual value",
+   "Glob": "MountedDevices",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Windows Portable Devices",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of USB devices previously connected to this system",
+   "Glob": "Microsoft\\Windows Portable Devices",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "SCSI",
+   "Category": "Devices",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of SCSI devices connected to this system",
+   "Glob": "ControlSet*\\Enum\\SCSI",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Network Shares",
+   "Category": "Network Shares",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the UNC path for a mounted network share",
+   "Glob": "*\\Network\\**\\RemotePath",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Network Shares",
+   "Category": "Network Shares",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the user account associated with the mounted network share",
+   "Glob": "*\\Network\\**\\UserName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Network Shares",
+   "Category": "Network Shares",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the provider of the mounted network share",
+   "Glob": "*\\Network\\**\\ProviderName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Network Drive MRU",
+   "Category": "Network Shares",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays drives that were mapped by the user",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Map Network Drive MRU",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Network Shares",
+   "Category": "Network Shares",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the share names and permissions of network shares",
+   "Glob": "ControlSet00*\\Services\\LanmanServer\\Shares\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "User Accounts (SAM)",
+   "Category": "User Accounts",
+   "Author": "Andrew Rathbun",
+   "Comment": "User accounts in SAM hive",
+   "Glob": "SAM\\Domains\\Account\\Users",
+   "Root": "SAM"
+  },
+  {
+   "Description": "User Accounts (SOFTWARE)",
+   "Category": "User Accounts",
+   "Author": "Andrew Rathbun",
+   "Comment": "User accounts in SOFTWARE hive",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\ProfileList",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "User Accounts (SECURITY)",
+   "Category": "User Accounts",
+   "Author": "Andrew Rathbun",
+   "Comment": "Built-in accounts in SECURITY hive",
+   "Glob": "Policy\\Accounts\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Security"
+  },
+  {
+   "Description": "Built-in User Accounts (SAM)",
+   "Category": "User Accounts",
+   "Author": "Andrew Rathbun",
+   "Comment": "Built-in accounts in SAM hive",
+   "Glob": "SAM\\Domains\\Builtin\\Aliases",
+   "Root": "SAM"
+  },
+  {
+   "Description": "Sysinternals",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays all SysInternals Tools that had the EULA accepted, indicating either execution of the tool or the Registry values were added intentionally prior to execution",
+   "Glob": "*\\SOFTWARE\\Sysinternals\\*\\EulaAccepted",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Program=x.OSPath[-2], FirstRunTimestamp=x.Mtime)\n"
+  },
+  {
+   "Description": "RecentApps",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Comment": "RecentApps",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Search\\RecentApps\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "MuiCache (Vista+)",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays new applications that have been executed within Windows",
+   "Glob": "*\\Software\\ClassesLocal Settings\\Software\\Microsoft\\Windows\\Shell\\MuiCache",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "MuiCache (2000/XP/2003)",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays new applications that have been executed within Windows",
+   "Glob": "*\\Software\\ClassesSoftware\\Microsoft\\Windows\\ShellNoRoam\\MUICache",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Pinned Taskbar Items",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays pinned Taskbar items",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TaskBand\\Favorites",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TypedPaths",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays paths that were typed by the user in Windows Explorer",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TypedPaths",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TypedURLs",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer/Edge Typed URLs",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\TypedURLs",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office MRU",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Comment": "Microsoft Office Recent Files, lower Item value (Value Name) = more recent",
+   "Glob": "*\\SOFTWARE\\Microsoft\\Office\\*\\*\\User MRU\\*\\File MRU",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "FirstFolder",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Comment": "FirstFolder, tracks the application's first folder that is presented to the user during an Open or Save As operation",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\FirstFolder\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "RunNotification",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "New in Windows 11, compare with other more researched Autoruns artifacts",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunNotification",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run32\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run32\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Startup Programs",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of programs that start up upon system boot",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "VNC Viewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays artifactrs relating to VNC Viewer",
+   "Glob": "*\\Software\\RealVNC\\vncviewer\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the name of the QNAP as it was assigned by the user",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the IP Address of the QNAP as it was assigned by the user",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrIPAddr",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the current firmware version of the QNAP",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrVersion",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the type of the QNAP device",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrType",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the model of the QNAP device",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\WOL\\*\\SvrModel",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "QNAP QFinder",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the install date of QNAP QFinder",
+   "Glob": "*\\SOFTWARE\\QNAP\\Qfinder\\InstallDate",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Total Commander",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Total Commander Registry artifacts",
+   "Glob": "Ghisler\\Total Commander",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Total Commander",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Total Commander Registry artifacts",
+   "Glob": "WOW6432Node\\Ghisler\\Total Commander",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "TeamViewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows username of logged in user",
+   "Glob": "*\\Software\\TeamViewer\\Meeting_UserName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TeamViewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "User's email associated with TeamViewer",
+   "Glob": "*\\Software\\TeamViewer\\BuddyLoginName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TeamViewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "User specified TeamViewer display name",
+   "Glob": "*\\Software\\TeamViewer\\BuddyDisplayName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TeamViewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the name of the user logged into TeamViewer",
+   "Glob": "WOW6432Node\\TeamViewer\\OwningManagerAccountName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "TeamViewer",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the date the password was last set for the user within TeamViewer",
+   "Glob": "WOW6432Node\\TeamViewer\\PermanentPasswordDate",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Adobe cRecentFiles",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays files which were opened Adobe Reader by the user",
+   "Glob": "*\\Software\\Adobe",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Adobe cRecentFolders",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays folders where Adobe Reader opened a PDF file from",
+   "Glob": "*\\Software\\Adobe\\Acrobat Reader\\DC\\AVGeneral\\cRecentFolders\\*\\tDIText",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "VisualStudio FileMRUList",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\VisualStudio\\*\\FileMRUList",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "VisualStudio MRUItems",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\VisualStudio\\*\\MRUItems\\*\\Items",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "VisualStudio MRUSettings",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\VisualStudio\\*\\NewProjectDialog\\MRUSettingsLocalProjectLocationEntries",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "7-Zip",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of files and folders that were used with 7-Zip",
+   "Glob": "*\\Software\\7-Zip\\Compression\\ArcHistory",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WinRAR",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays history of archives that were used with WinRAR",
+   "Glob": "*\\Software\\WinRAR",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Eraser",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Potential evidence of anti-forensics",
+   "Glob": "*\\Software\\Eraser\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "LogMeIn",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "LogMeIn GoToMeeting",
+   "Glob": "*\\Software\\LogMeIn\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Macrium Reflect image storage directory",
+   "Glob": "*\\Software\\Macrium\\Reflect\\Recent Folders\\Image\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays files that are not to be included in Macrium Reflect images",
+   "Glob": "ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshotMacriumImage\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Command last ran by user",
+   "Glob": "Macrium\\**\\LastRun",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "registered user",
+   "Glob": "Macrium\\**\\Licensee",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays timestamps related to Macrium Reflect's CBT feature",
+   "Glob": "Macrium\\Reflect\\CBT\\Sequence\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFILETIME(t=x.Data)"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays default settings associated with Macrium Reflect on this computer",
+   "Glob": "Macrium\\Reflect\\Defaults\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays Macrium Image Guardian status",
+   "Glob": "Macrium\\Reflect\\ImageGuardian",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays SID associated with Macrium Reflect on this computer",
+   "Glob": "Macrium\\Reflect\\Security\\**\\SID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the application path associated with Macrium Reflect on this computer",
+   "Glob": "Macrium\\Reflect\\Security\\**\\App Path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Macrium Image Guardian Status, 1 = protected",
+   "Glob": "Macrium\\Reflect\\MIG\\Verified\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Macrium Reflect",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays settings related to Macrium Reflect's interaction with VSS",
+   "Glob": "Macrium\\Reflect\\VSS\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "WinSCP",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "WinSCP",
+   "Glob": "*\\Software\\Martin Prikryl\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WinSCP",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "WinSCP",
+   "Glob": "WOW6432Node\\Martin Prikryl\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Ares",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays information relating to Ares",
+   "Glob": "Ares\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Soulseek",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the name of the user who installed Soulseek",
+   "Glob": "WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\?8A4E1646-488C-4E5B-AC31-F784400E8D2D?_is1\\**\\Inno Setup: User",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Soulseek",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the language for which Soulseek was installed",
+   "Glob": "WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\?8A4E1646-488C-4E5B-AC31-F784400E8D2D?_is1\\**\\Inno Setup: Language",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Signal",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the location where Signal is installed on the user's computer",
+   "Glob": "*\\Software\\7d96caee-06e6-597c-9f2f-c7bb2e0948b4\\**\\InstallLocation",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Stardock Fences",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of links the user had on their desktop at the time of installation",
+   "Glob": "*\\Software\\Stardock\\Fences\\InitialSnapshot\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Stardock Fences",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of icons on the user's desktop",
+   "Glob": "*\\Software\\Stardock\\Fences\\Icons\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Stardock Fences",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of connected monitors to the user's computer",
+   "Glob": "*\\Software\\Stardock\\Fences\\Settings\\**\\ResolutionLast",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Stardock Fences",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the user's primary monitor",
+   "Glob": "*\\Software\\Stardock\\Fences\\Settings\\**\\PrimaryMonitorLast",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "4K Video Downloader",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the run count for 4K Video Downloader",
+   "Glob": "*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Notification\\runCount",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "4K Video Downloader",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the last version of 4K Video Downloader installed on this system",
+   "Glob": "*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Notification\\lastVersion",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "4K Video Downloader",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the date that 4K Video Downloader was installed",
+   "Glob": "*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Limits\\dayDownloadDate",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003etimestamp(epoch=x.Data)"
+  },
+  {
+   "Description": "4K Video Downloader",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the amount of times 4K Video Downloaded was downloaded",
+   "Glob": "*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Limits\\dayDownloadCount",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "4K Video Downloader",
+   "Category": "Third Party Applications",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the location of the SQLite database associated with 4K Video Downloader",
+   "Glob": "*\\SOFTWARE\\4kdownload.com\\4K Video Downloader\\Download\\downloadedItemsDb",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays folders present within a user's OneDrive",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Internet\\Server*\\http*\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the user's (check HivePath) specified storage location for OneDrive",
+   "Glob": "*\\Environment\\OneDriveConsumer",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the user's specified storage location for OneDrive",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\OneDrive*\\UserSyncRoots\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the Last Modified time for the OneDrive Registry key",
+   "Glob": "*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\LastModifiedTime",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays where the OneDrive folder is mounted",
+   "Glob": "*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\MountPoint",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the URL Namespace for OneDrive",
+   "Glob": "*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\UrlNamespace",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Office Sync Integration, 0 = Disabled, 1 = Enabled",
+   "Glob": "*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\IsOfficeSyncIntegrationEnabled",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\SyncEngines\\Providers\\OneDrive\\*\\**\\LibraryType",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the installation path from the user's AppData folder for OneDrive",
+   "Glob": "*\\Software\\Microsoft\\OneDrive\\*\\**\\InstallPath",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "OneDrive",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the last update time of the Accounts OneDrive Registry key",
+   "Glob": "*\\Software\\Microsoft\\OneDrive\\Accounts\\**\\LastUpdate",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003etimestamp(epoch=x.Data)"
+  },
+  {
+   "Description": "Dropbox",
+   "Category": "Cloud Storage",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the user's specified storage location for Dropbox",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\SyncRootManager\\Dropbox*\\UserSyncRoots\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Event Logs Logging Status",
+   "Category": "Event Logs",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Windows Event Log Channels (Key Path) on this system, 0 = Disabled, 1 - Enabled",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\WINEVT\\Channels\\**\\Enabled",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Application Event Log Providers",
+   "Category": "Event Logs",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Providers within the Application Event Log on this system, 0 = Disabled, 1 - Enabled",
+   "Glob": "ControlSet001\\Control\\WMI\\Autologger\\EventLog-Application\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "System Event Log Providers",
+   "Category": "Event Logs",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Providers within the Application Event Log on this system, 0 = Disabled, 1 - Enabled",
+   "Glob": "ControlSet001\\Control\\WMI\\Autologger\\EventLog-System\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists email addresses registered to Microsoft Office on the user's system",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\EmailAddresses",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists email address registered to Microsoft Office on the user's system",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\EmailAddress",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists first name for the registered Microsoft Office user",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\FirstName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists last name for the registered Microsoft Office user",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\LastName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists full name for the registered Microsoft Office user",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\FriendlyName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Lists initials for the registered Microsoft Office user",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\Initials",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays time user was authenticated to the system's instance of Microsoft 365 for the first time",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Identities\\*\\AuthHistory\\**",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFILETIME(t=x.Data)"
+  },
+  {
+   "Description": "Microsoft Office",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays time user was authenticated to the system's instance of Microsoft 365 for the first time",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Identity\\Profiles\\*\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Office Trusted Documents",
+   "Category": "Microsoft Office",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays list of Office documents where the user may have clicked Enable Editing, Enable Macro, or Enable Content",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\*\\Security\\Trusted Documents\\TrustRecords\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Exchange Patch Status",
+   "Category": "Microsoft Exchange",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the date the patch was installed on this host",
+   "Glob": "Microsoft\\Updates\\Exchange*\\KB*\\InstalledDate",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Exchange Patch Status",
+   "Category": "Microsoft Exchange",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the name of the patch installed on this host",
+   "Glob": "Microsoft\\Updates\\Exchange*\\KB*\\PackageName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Exchange Patch Status",
+   "Category": "Microsoft Exchange",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the date the patch was installed on this host",
+   "Glob": "Microsoft\\Updates\\Exchange*\\SP*\\KB*\\InstalledDate",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Exchange Patch Status",
+   "Category": "Microsoft Exchange",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the name of the patch installed on this host",
+   "Glob": "Microsoft\\Updates\\Exchange*\\SP*\\KB*\\PackageName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Google Chrome",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Google Chrome Registry artifacts",
+   "Glob": "*\\Software\\Google\\Chrome\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Main",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Download Directory",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\NewWindows",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Suggested Sites\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\ProtocolExecute\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\LowRegistry\\IEShims\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Main\\WindowsSearch\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Explorer",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Internet Explorer Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Main\\WindowsSearch",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Microsoft Edge",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "Microsoft Edge Registry artifacts",
+   "Glob": "*\\Software\\Microsoft\\Edge\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CCleaner Browser",
+   "Category": "Web Browsers",
+   "Author": "Andrew Rathbun",
+   "Comment": "CCleaner Browser Registry artifacts",
+   "Glob": "WOW6432Node\\Piriform\\Browser\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "File Extensions",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Tracks programs associated with file extensions",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Add/Remove Programs Entries",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays installed software",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Uninstall",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Add/Remove Programs Entries",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays installed software",
+   "Glob": "WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Add/Remove Programs Entries",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays installed software",
+   "Glob": "*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Products",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays all installed software packages",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Installer\\UserData\\*\\Products",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows App List",
+   "Category": "Installed Software",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays all Windows applications installed on this system",
+   "Glob": "*\\Software\\ClassesLocal Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\Repository",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "VSS",
+   "Category": "Volume Shadow Copies",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays files to be deleted from newly created shadow copies",
+   "Glob": "ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshot\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "VSS",
+   "Category": "Volume Shadow Copies",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays files to be deleted from newly created shadow copies",
+   "Glob": "ControlSet*\\Control\\BackupRestore\\FilesNotToSnapshotSave\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "VSS",
+   "Category": "Volume Shadow Copies",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the names of the Registry subkeys and values that backup applications should not restore",
+   "Glob": "ControlSet*\\Control\\BackupRestore\\KeysNotToRestore\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "VSS",
+   "Category": "Volume Shadow Copies",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the names of the files and directories that backup applications should not backup or restore",
+   "Glob": "ControlSet*\\Control\\BackupRestore\\FilesNotToBackup\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Shadow RDP Sessions",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Shadow RDP sessions, 0 = Disabled, 1 = Full Control with user's permission, 2 = Full Control without user's permission, 3 = View Session with user's permission, 4 = View Session without user's permission",
+   "Glob": "Policies\\Microsoft\\Windows NT\\Terminal Services\\**\\Shadow",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "RDP Connections Status",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of whether the system can accept Terminal Server (RDP) connections, 0 = Disabled (Inbound RDP enabled), 1 = Enabled (Inbound RDP disabled)",
+   "Glob": "ControlSet*\\Control\\Terminal Server\\**\\fDenyTSConnections",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "RDP User Authentication Status",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays whether a Network-Level user authentication is required before a remote desktop connection is established. 0 = Disabled (no authentication required), 1 = Enabled (authentication required)",
+   "Glob": "ControlSet*\\Control\\Terminal Server\\WinStations\\RDP-Tcp\\**\\UserAuthentication",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender Status",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of whether Windows Defender AntiSpyware is enabled or not. 0 = Enabled, 1 = Disabled",
+   "Glob": "Policies\\Microsoft\\Windows Defender\\**\\DisableAntiSpyware",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender Status",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of whether Windows Defender AntiVirus is enabled or not. 0 = Enabled, 1 = Disabled",
+   "Glob": "Policies\\Microsoft\\Windows Defender\\**\\DisableAntiVirus",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Antivirus",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender DisableBlockAtFirstSeen Status, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Antivirus",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender SpynetReporting Status, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\Windows Defender\\SpyNet\\SpynetReporting",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Antivirus",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender SubmitSamplesConsent Status, 0 = Disabled, 1 = Enabled",
+   "Glob": "Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "PortProxy Configuration",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays current port proxy configuration",
+   "Glob": "ControlSet*\\Services\\PortProxy\\v4tov4\\tcp\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Exefile Shell Open Command",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Exefile hijack shows e.g. path to a binary",
+   "Glob": "Classes\\Exefile\\Shell\\Open\\Command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Exefile Shell Open Command",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Exefile hijack shows e.g. path to a binary",
+   "Glob": "*\\Software\\ClassesExefile\\Shell\\Open\\Command\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Disabled, 1 = Enabled",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\UseAdvancedStartup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "1 = Default, 0 = Disabled, 1 = Enabled",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\EnableBDEWithNoTPM",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Do Not Allow TPM, 1 = Require TPM, 2 = Allow TPM",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\UseTPM",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Do not allow startup key with TPM, 1 = Require startup key with TPM, 2 = Allow startup key with TPM",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\UseTPMKey",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Do not allow startup key and PIN with TPM, 1 = Require startup key and PIN with TPM, 2 = Allow startup key and PIN with TPM",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\UseTPMKeyPIN",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the Recovery Key message set by the Threat Actor group",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\RecoveryKeyMessage",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "2 is set by the Hades group",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\RecoveryKeyMessageSource",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Hades IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "0 = Do not allow startup PIN with TPM, 1 = Require startup PIN with TPM, 2 = Allow startup PIN with TPM",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\UseTPMPIN",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "REvil IOCs",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "REvil/Kaseya Ransomware attack from July 2021",
+   "Glob": "Wow6432Node\\BlackLivesMatter\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "PowerShell Info",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Cobalt Strike Reflection Attack - Lockbit 2.0",
+   "Glob": "Microsoft\\PowerShell\\info",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Restricted Admin Status",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the status of Restricted Admin mode",
+   "Glob": "ControlSet*\\Control\\Lsa\\DisableRestrictedAdmin",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled",
+   "Glob": "Microsoft\\Windows Defender\\Real-Time Protection",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Symantec Endpoint Protection",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays a list of filenames that have been quarantined by Symantec Endpoint Protection",
+   "Glob": "WOW6432Node\\Symantec\\Symantec Endpoint Protection\\AV\\Quarantine\\QRecords\\*\\FName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled",
+   "Glob": "Microsoft\\Windows Defender\\Reporting",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender Real-Time Protection Status, 0 = Enabled, 1 = Disabled",
+   "Glob": "Microsoft\\Windows Defender\\fDenyTSConnections",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eExtractValueFromComment(x=x)"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender Exclusions through Group Policies (GPOs)",
+   "Glob": "Policies\\Microsoft\\Windows Defender\\Exclusions\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows Defender",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Windows Defender Exclusions",
+   "Glob": "Microsoft\\Windows Defender\\Exclusions\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Image File Execution Options Injection",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "See documentation in Batch File for further information",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\Debugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Image File Execution Options Injection",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "See documentation in Batch File for further information",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Connections Made By MS Office",
+   "Category": "Threat Hunting",
+   "Author": "Andrew Rathbun",
+   "Comment": "Displays the connections made by MS Office - IOCs found here for CVE-2022-30190",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Common\\Internet\\Server Cache\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Select ControlSet",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Select",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "ServiceControlManagerExtension",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\ServiceControlManagerExtension",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "BootVerificationProgram",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\BootVerificationProgram\\Imagepath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "LSA Authentication Packages",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\LSA\\Authentication Packages",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "LSA Notification Packages",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\LSA\\Notification Packages",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "LSA Security Packages",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\LSA\\Security Packages",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "LSA OsConfig",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\LSA\\OsConfig\\Security Packages",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "NetworkProvider Order",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\NetworkProvider\\*\\**\\ProviderOrder",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Print Driver",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Print\\Monitors\\*\\**\\Driver",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Print Providers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Print\\Providers\\*\\**\\Name",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "SafeBoot",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\SafeBoot\\AlternateShell",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "SafeBoot Minimal",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\SafeBoot\\Minimal\\*\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "SafeBoot Network",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\SafeBoot\\Network\\*\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "SecurityProviders",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\SecurityProviders\\SecurityProviders",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager BootExecute",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\BootExecute",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager BootShell",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\BootShell",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager Execute",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\Execute",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager InitialCommand",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\InitialCommand",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager InitialCommand",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\*InitialCommand",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager PendingFileRenameOperations",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\PendingFileRenameOperations",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager PendingFileRenameOperations*",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\PendingFileRenameOperations*",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager SETUPEXECUTE",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\SetUpExecute",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager KnownDLLs",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\KnownDLLs",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Session Manager SubSystems",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Session Manager\\SubSystems",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Terminal Server StartupPrograms",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Terminal Server\\Wds\\rdpwd\\StartupPrograms",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Terminal Server WinStations RDP-Tcp",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\Terminal Server\\WinStations\\RDP-Tcp\\TSMMRemotingAllowedApps",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WOW KnownDLLs",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Control\\WOW\\KnownDLLs",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services AutoRun",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\AutoRun",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services BootFlags",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\BootFlags",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services DelayedAutoStart",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\DelayedAutoStart",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services DependOnService",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\DependOnService",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services Description",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\Description",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services DisplayName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\DisplayName",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ErrorControl",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ErrorControl",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services Group",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\Group",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ImagePath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ImagePath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services Library",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\Library",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ObjectName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ObjectName",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ProviderPath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ProviderPath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ProxyDllFile",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ProxyDllFile",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services RequiredPrivileges",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\RequiredPrivileges",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ServiceDll",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ServiceDll",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ServiceMain",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ServiceMain",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services ServiceSidType",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\ServiceSidType",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services Start",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\Start",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Services Type",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\*\\**\\Type",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 AppId_Catalog AppFullPath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\AppId_Catalog\\*\\AppFullPath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 AppId_Catalog AppArgs",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\AppId_Catalog\\*\\AppArgs",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 DisplayString",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\DisplayString",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 Enabled",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\Enabled",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 LibraryPath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries\\*\\LibraryPath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 64 DisplayString",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\DisplayString",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 64 Enabled",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\Enabled",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 NameSpace_Catalog5 64 LibraryPath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\NameSpace_Catalog5\\Catalog_Entries64\\*\\LibraryPath",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 Protocol_Catalog9 ProtocolName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\Protocol_Catalog9\\Catalog_Entries\\*\\ProtocolName",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "WinSock2 Protocol_Catalog9 64 ProtocolName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "ControlSet*\\Services\\WinSock2\\Parameters\\Protocol_Catalog9\\Catalog_Entries64\\*\\ProtocolName",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Setup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Setup\\CmdLine",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": ".cmd",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\.cmd\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": ".cmd PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\.cmd\\PersistentHandler\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": ".exe",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\.exe\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": ".exe PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\.exe\\PersistentHandler\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shell Open Command",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shell\\**\\DelegateExecute",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shell Runas command",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shell\\**\\IsolatedCommand",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx ColumnHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\ColumnHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx ContextMenuHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\ContextMenuHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shellex ContextMenuHandlers InstallFont",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shellex\\ContextMenuHandlers\\InstallFont\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shellex ContextMenuHandlers Open With",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shellex\\ContextMenuHandlers\\Open With\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shellex ContextMenuHandlers Open With EncryptionMenu",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shellex\\ContextMenuHandlers\\Open With EncryptionMenu\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx ContextMenuHandlers OpenContainingFolderMenu",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\ContextMenuHandlers\\OpenContainingFolderMenu\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "shellex ContextMenuHandlers PlayTo",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\shellex\\ContextMenuHandlers\\PlayTo\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx CopyHookHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\CopyHookHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx DragDropHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\DragDropHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx ExtShellFolderViews",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\ExtShellFolderViews\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEX IconHandler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEX\\IconHandler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellEx PropertySheetHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\*\\ShellEx\\PropertySheetHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\InprocServer32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\InprocServer32\\Assembly",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID Instance CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\Instance\\**\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID Instance FriendlyName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\Instance\\**\\FriendlyName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\LocalServer32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\LocalServer32\\Assembly",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\PersistentHandler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "CLSID TypeLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\CLSID\\*\\TypeLib\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "cmdfile shell open command",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\cmdfile\\shell\\open\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Directory background shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Directory\\background\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Directory shellex CopyHookHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Directory\\shellex\\CopyHookHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Directory shellex DragDropHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Directory\\shellex\\DragDropHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Directory shellex PropertySheetHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Directory\\shellex\\PropertySheetHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Drive shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Drive\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Classes Filter",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Filter\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Folder shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Folder\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Folder shellex DragDropHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Folder\\shellex\\DragDropHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Folder shellex PropertySheetHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Folder\\shellex\\PropertySheetHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "htmlfile shell open command",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\htmlfile\\shell\\open\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Interface ProxyStubClsid32",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Interface\\*\\ProxyStubClsid32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Interface TypeLib",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Interface\\*\\TypeLib\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Protocols Filter",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Protocols\\Filter\\*\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Protocols Handler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Protocols\\Handler\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Protocols Handler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Protocols\\Handler\\*\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Protocols Name-Space Handler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Protocols\\Name-Space Handler\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Protocols Name-Space Handler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Protocols\\Name-Space Handler\\*\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "SystemFileAssociations ShellEx ContextMenuHandlers ShellImagePreview",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\SystemFileAssociations\\*\\ShellEx\\ContextMenuHandlers\\ShellImagePreview\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "TypeLib win32",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\TypeLib\\*\\*\\*\\win32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "TypeLib win64",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\TypeLib\\*\\*\\*\\win64\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shell Open Command",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shell\\**\\DelegateExecute",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shell Runas command",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shell\\**\\IsolatedCommand",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx ColumnHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\ColumnHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx ContextMenuHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\ContextMenuHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shellex ContextMenuHandlers InstallFont",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\InstallFont\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shellex ContextMenuHandlers Open With",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\Open With\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shellex ContextMenuHandlers Open With EncryptionMenu",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\Open With EncryptionMenu\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx ContextMenuHandlers OpenContainingFolderMenu",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\ContextMenuHandlers\\OpenContainingFolderMenu\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 shellex ContextMenuHandlers PlayTo",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\shellex\\ContextMenuHandlers\\PlayTo\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx CopyHookHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\CopyHookHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx DragDropHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\DragDropHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx ExtShellFolderViews",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\ExtShellFolderViews\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEX IconHandler",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEX\\IconHandler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellEx PropertySheetHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\*\\ShellEx\\PropertySheetHandlers\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\InprocServer32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\InprocServer32\\Assembly",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID Instance CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\Instance\\**\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID Instance FriendlyName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\Instance\\**\\FriendlyName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\LocalServer32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\LocalServer32\\Assembly",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\PersistentHandler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 CLSID TypeLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\CLSID\\*\\TypeLib\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Directory background shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Directory\\background\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Directory shellex CopyHookHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Directory\\shellex\\CopyHookHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Directory shellex DragDropHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Directory\\shellex\\DragDropHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Directory shellex PropertySheetHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Directory\\shellex\\PropertySheetHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Drive shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Drive\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Classes Filter",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Filter\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Folder shellex ContextMenuHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Folder\\shellex\\ContextMenuHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Folder shellex DragDropHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Folder\\shellex\\DragDropHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Folder shellex PropertySheetHandlers",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Folder\\shellex\\PropertySheetHandlers\\*\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Interface ProxyStubClsid32",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Interface\\*\\ProxyStubClsid32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Interface TypeLib",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\Interface\\*\\TypeLib\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 TypeLib win32",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\TypeLib\\*\\*\\*\\win32\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 TypeLib win64",
+   "Category": "ASEP Classes",
+   "Author": "Troy Larson",
+   "Glob": "Classes\\Wow6432Node\\TypeLib\\*\\*\\*\\win64\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "StartMenuInternet shell open command",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Clients\\StartMenuInternet\\*\\shell\\open\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "StartMenuInternet shell naom command",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Clients\\StartMenuInternet\\*\\shell\\naom\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "StartMenuInternet Shell RunAs Command",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Clients\\StartMenuInternet\\*\\Shell\\RunAs\\Command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Chrome Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Google\\Chrome\\Extensions\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Google Update",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Google\\Update\\path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": ".NETFramework",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\.NETFramework\\DbgManagedDebugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Command Processor",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Command Processor\\autorun",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Cryptography Offload",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Cryptography\\Offload\\**\\ExpoOffload",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Ctf LangBarAddin",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Ctf\\LangBarAddin\\**\\Filepath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Approved Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Approved Extensions\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Explorer Bars",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Explorer Bars\\*\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Extension Validation",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Extension Validation\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Extensions\\**\\ClsidExtension",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Low Rights DragDrop",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Low Rights DragDrop",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppPath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Low Rights ElevationPolicy",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Low Rights ElevationPolicy",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppPath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Low Rights ElevationPolicy",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Plugins Extension",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Plugins\\Extension\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Toolbar",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Toolbar",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Toolbar ShellBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer Toolbar WebBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\Toolbar\\WebBrowser",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Explorer URLSearchHooks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Internet Explorer\\URLSearchHooks",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Office\\*\\Addins\\**\\Description",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Office\\*\\Addins\\**\\FriendlyName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Office\\*\\Addins\\**\\LoadBehavior",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Authentication Credential Provider Filters",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider Filters\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Authentication Credential Providers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Providers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Authentication PLAP Providers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Authentication\\PLAP Providers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer Browser Helper Objects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer FindExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer FindExtensions Static",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\Static\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer SharedTaskScheduler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer ShellExecuteHooks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellExecuteHooks\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer ShellIconOverlayIdentifiers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer ShellServiceObjects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**\\autostart",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Ext PreApproved",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Ext\\PreApproved\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Group Policy Scripts Shutdown",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Shutdown\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Group Policy Scripts Startup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Startup\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Internet Settings",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Explorer Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Policies\\System\\UIHost",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Userinit",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "RunOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Runonce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "RunOnce Setup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Runonce\\Setup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "RunOnceEx",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "RunServices",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\RunServices",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "RunServicesOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\RunServicesOnce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "SharedDLLs",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Shareddlls",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Shell Extensions Approved",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "ShellServiceObjectDelayLoad",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Installed SDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\InstallDate",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Installed SDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\DisplayName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\auto",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\Debugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\UserDebuggerHotKey",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags Custom",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseDescription",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseInstallTimeStamp",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabasePath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseType",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "AppCompatFlags Layers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\Current Version\\AppCompatFlags\\Layers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Drivers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Drivers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Drivers32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Drivers32",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Font Drivers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Font Drivers\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Image File Execution Options",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\GlobalFlag",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Image File Execution Options",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\Debugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Boot",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Boot\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Logon\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Maintenance",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Maintenance\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Plain",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Plain\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Actions",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Author",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Description",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\DynamicInfo",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Hash",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Schema",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\SecurityDescriptor",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Source",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Triggers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\URI",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Version",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Schedule TaskCache Tree",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\**\\Id",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "SilentProcessExit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\ReportingMode",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "SilentProcessExit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\MonitorProcess",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Windows NT SvcHost",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\SvcHost\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Windows NT Terminal Server Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Windows NT Terminal Server Runonce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Windows NT Terminal Server Runonceex",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonceex",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Microsoft Windows NT OsImagesFolder",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Comment": "Looking for OsImagesFolder.",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\LayerRootLocations\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows NT CV Windows AppInitDlls",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows NT CV Windows IconServiceLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\IconServiceLib",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows NT CV Windows Load",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Windows NT CV Windows Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon GinaDLL",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Ginadll",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon Userinit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon VMApplet",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMApplet",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon AppSetup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AppSetup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon Shell",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\System",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon Taskman",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Taskman",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon UIHost",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\UIHost",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon AlternateShells AvailableShells",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AlternateShells\\AvailableShells",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\DisplayName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\dllname",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Winlogon Notify",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify\\**\\dllname",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "MozillaPlugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "MozillaPlugins\\*\\path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\**\\Script",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\**\\Script",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies Scripts Shutdown",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\**\\Script",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Policies Scripts Startup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\**\\Script",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Google Update",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Google\\Update\\path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "WOW6432 .NETFramework",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "WOW6432Node\\Microsoft\\.NETFramework\\DbgManagedDebugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "WOW6432 Command Processor Autorun",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Command Processor\\Autorun",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Ctf LangBarAddin",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Ctf\\LangBarAddin\\**\\Filepath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Approved Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Approved Extensions\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Explorer Bars",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Explorer Bars\\*\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Extension Validation",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Extension Validation\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Extensions\\**\\ClsidExtension",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Low Rights DragDrop",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Low Rights DragDrop",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\DragDrop\\**\\AppPath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Low Rights ElevationPolicy AppName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Low Rights ElevationPolicy AppPath",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\AppPath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Low Rights ElevationPolicy CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Low Rights\\ElevationPolicy\\**\\CLSID",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Plugins Extension",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Plugins\\Extension\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Toolbar",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Toolbar ShellBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE Toolbar WebBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\Toolbar\\WebBrowser",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 IE URLSearchHooks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Internet Explorer\\URLSearchHooks",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\Description",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\FriendlyName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Office\\*\\Addins\\**\\LoadBehavior",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Authentication Credential Provider Filters",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider Filters\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Authentication Credential Providers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Providers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Authentication PLAP Providers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Authentication\\PLAP Providers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer Browser Helper Objects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer FindExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer FindExtensions Static",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FindExtensions\\Static\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer SharedTaskScheduler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer ShellExecuteHooks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellExecuteHooks\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer ShellIconOverlayIdentifiers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Explorer ShellServiceObjects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**\\autostart",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Ext PreApproved",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Ext\\PreApproved\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Internet Settings",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 RunOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Runonce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 RunOnce Setup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Runonce\\Setup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 RunOnceEx",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 RunServices",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunServices",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 RunServicesOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunServicesOnce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 SharedDLLs",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Shareddlls",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Shell Extensions Approved",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 ShellServiceObjectDelayLoad",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Installed SDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\InstallDate",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Installed SDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*.sdb\\**\\DisplayName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\auto",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\Debugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AeDebug",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\**\\UserDebuggerHotKey",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseDescription",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseInstallTimeStamp",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabasePath",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AppCompatFlags InstalledSDB",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB\\**\\DatabaseType",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 AppCompatFlags Layers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\Current Version\\AppCompatFlags\\Layers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Drivers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Drivers32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Font Drivers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Font Drivers\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Image File Execution Options",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\GlobalFlag",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Image File Execution Options",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\**\\Debugger",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Boot",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Boot\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Logon\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Maintenance",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Maintenance\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Plain",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Plain\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Actions",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Author",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Description",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\DynamicInfo",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Hash",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Schema",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\SecurityDescriptor",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Source",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Triggers",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\URI",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tasks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\**\\Version",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Schedule TaskCache Tree",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\**\\Id",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 SilentProcessExit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\ReportingMode",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 SilentProcessExit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\**\\MonitorProcess",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT SvcHost",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SvcHost\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT Terminal Server Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT Terminal Server Runonce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonce",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT Terminal Server Runonceex",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\install\\Software\\Microsoft\\Windows\\CurrentVersion\\Runonceex",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT OsImagesFolder",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Comment": "Looking for OsImagesFolder.",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Virtualization\\LayerRootLocations\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Microsoft Windows NT CurrentVersion Windows",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Windows NT CV Windows IconServiceLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\IconServiceLib",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Windows NT CV Windows Load",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Windows NT CV Windows Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon GinaDLL",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Ginadll",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon Userinit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon VMApplet",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMApplet",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon AppSetup",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AppSetup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon Shell",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\System",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon Taskman",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Taskman",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon UIHost",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\UIHost",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon AlternateShells AvailableShells",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\AlternateShells\\AvailableShells",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\DisplayName",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon GPExtensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\GPExtensions\\**\\dllname",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 Winlogon Notify",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Notify\\**\\dllname",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Wow6432 MozillaPlugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "Wow6432Node\\MozillaPlugins\\*\\path",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Desktop Wallpaper",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Control Panel\\DeskTop\\ConvertedWallpaper",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Desktop Wallpaper",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Control Panel\\DeskTop\\OriginalWallpaper",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Desktop Wallpaper",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Control Panel\\DeskTop\\WallPaper",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Desktop Screensaver",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Control Panel\\DeskTop\\scrnsave.exe",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Environment Logon Script",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Environment\\UserInitMprLogonScript",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Chrome Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Google\\Chrome\\Extensions\\**\\path",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Command Processor",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Command Processor\\autorun",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Ctf LangBarAddin",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Ctf\\LangBarAddin",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Approved Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Approved Extensions",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE DeskTop Components",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\DeskTop\\Components\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE BackupWallpaper",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Desktop\\General\\BackupWallpaper",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE wallpapersource",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Desktop\\General\\wallpapersource",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Explorer Bars",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Explorer Bars\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Extension Validation",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Extension Validation\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Extensions",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Extensions\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE MenuExt",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\MenuExt\\**\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Toolbar ShellBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Toolbar\\ShellBrowser",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE Toolbar WebBrowser",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\Toolbar\\WebBrowser",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "IE URLSearchHooks",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Internet Explorer\\URLSearchHooks",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Addins",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Office\\*\\Addins\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Explorer Browser Helper Objects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Explorer SharedTaskScheduler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SharedTaskScheduler\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Explorer ShellIconOverlayIdentifiers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellIconOverlayIdentifiers\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Explorer ShellServiceObjects",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ShellServiceObjects\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Ext Settings",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Ext\\Settings\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Ext Stats",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Ext\\Stats\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\DisplayName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\ExecTime",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\FileSysPath",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\GPO-ID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\IsPowershell",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\Parameters",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\PSScriptOrder",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\Script",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logoff",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logoff\\*\\**\\SOM-ID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\DisplayName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\ExecTime",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\FileSysPath",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\GPO-ID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon*\\**\\IsPowershell",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\Parameters",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\PSScriptOrder",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\Script",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Group Policy Scripts Logon",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\Scripts\\Logon\\*\\**\\SOM-ID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Settings AutoConfigProxy",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigProxy",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Internet Settings AutoConfigURL",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\AutoConfigURL",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies Explorer NoDriveTypeAutoRun",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\NoDriveTypeAutoRun",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies Explorer Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies System Shell",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies System",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\UserInit",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "RunOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "RunOnceEx",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "RunServices",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunServices",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "RunServicesOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\RunServicesOnce",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Shell Extensions Approved",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Shell Extensions\\Approved\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellServiceObjectDelayLoad",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\ShellServiceObjectDelayLoad\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Drivers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\drivers",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Drivers32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\drivers32",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Terminal Server Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Terminal Server RunOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Terminal Server RunOnceEx",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\Software\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Load",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Winlogon Shell",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Winlogon Userinit",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\userinit",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Winlogon VMapplet",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\VMapplet",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mozilla Components, Extensions, \u0026 Plugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Mozilla\\*\\Components\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mozilla Components, Extensions, \u0026 Plugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Mozilla\\*\\Extensions\\Components\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mozilla Components, Extensions, \u0026 Plugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Mozilla\\*\\Extensions\\Plugins\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mozilla Components, Extensions, \u0026 Plugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Mozilla\\*\\Plugins\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Mozilla Components, Extensions, \u0026 Plugins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\MozillaPlugins\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies Desktop Screensaver",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Policies\\Microsoft\\Windows\\Control Panel\\Desktop\\Scrnsave.exe",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies Logoff Script",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\**\\Script",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Policies Logon Script",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\**\\Script",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Domain Profile Authorized Applications",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\AuthorizedApplications\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Standard Profile Authorized Applications",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Policies\\Microsoft\\WindowsFirewall\\StandardProfile\\AuthorizedApplications\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432 Command Processor",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Command Processor\\autorun",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432 Internet Explorer Explorer Bars",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Internet Explorer\\Explorer Bars",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432 Internet Explorer Extension",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Internet Explorer\\Extension",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WOW6432Node Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Office\\*\\Addins",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WOW6432Node Office Addins",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Office\\*\\Addins\\*",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WOW6432Node Drivers32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32\\**",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WOW6432Node Run",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WOW6432Node RunOnce",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": ".cmd",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes.cmd\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": ".cmd PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes.cmd\\PersistentHandler\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": ".exe",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes.exe\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": ".exe PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes.exe\\PersistentHandler\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "cmdfile",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classescmdfile\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "exefile",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classesexefile\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Htmlfile Open",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesHtmlfile\\Shell\\Open\\Command\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx ColumnHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\ColumnHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx ContextMenuHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\ContextMenuHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx CopyHookHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\CopyHookHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx DragDropHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\DragDropHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx ExtShellFolderViews",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\ExtShellFolderViews\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ShellEx PropertySheetHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\Classes*\\ShellEx\\PropertySheetHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Directory Background ContextMenuHandlers",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesDirectory\\Background\\ShellEx\\ContextMenuHandlers\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\InprocServer32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\InprocServer32\\Assembly",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\LocalServer32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\LocalServer32\\Assembly",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\PersistentHandler",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID TypeLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\TypeLib\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID Instance CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\Instance\\**\\CLSID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "CLSID Instance FriendlyName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesCLSID\\*\\Instance\\**\\FriendlyName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Interface ProxyStubClsid32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesInterface\\*\\ProxyStubClsid32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Protocols CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesProtocols\\Filter\\*\\CLSID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Protocols Handler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesProtocols\\Handler\\*\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Protocols Handler CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesProtocols\\Handler\\*\\CLSID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Protocols Name-Space Handler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesProtocols\\Name-Space Handler\\*\\**\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "ProtocolsName-Space Handler CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesProtocols\\Name-Space Handler\\*\\**\\CLSID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TypeLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesTypeLib\\*\\*\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TypeLib Win32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesTypeLib\\*\\*\\*\\win32\\**\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "TypeLib Win64",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesTypeLib?*\\*\\*\\win64\\**\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\InprocServer32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID InprocServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\InprocServer32\\Assembly",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\LocalServer32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID LocalServer32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\LocalServer32\\Assembly",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID PersistentHandler",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\PersistentHandler",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID TypeLib",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\TypeLib\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID Instance CLSID",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\Instance\\**\\CLSID",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node CLSID Instance FriendlyName",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\CLSID\\*\\Instance\\**\\FriendlyName",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Wow6432Node Interface ProxyStubClsid32",
+   "Category": "ASEP",
+   "Author": "Troy Larson",
+   "Glob": "*\\Software\\ClassesWow6432Node\\Interface\\*\\ProxyStubClsid32\\@",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Parse AmCache InventoryApplicationFile",
+   "Category": "ASEP",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl",
+   "Glob": "Root\\InventoryApplication*\\*",
+   "Root": "Amcache",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Parse AmCache DriverBinary",
+   "Category": "ASEP",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl",
+   "Glob": "Root\\InventoryDriverBinary\\*",
+   "Root": "Amcache",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') + dict(Driver=OSPath.Basename)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Parse AmCache InventoryApplicationShortcut",
+   "Category": "ASEP",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amcache.pl",
+   "Glob": "Root\\InventoryApplicationShortcut\\*",
+   "Root": "Amcache",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Active Setup Installed Components",
+   "Category": "ASEP",
+   "Glob": "Microsoft\\Active Setup\\Installed Components\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Active Setup Installed Components",
+   "Category": "ASEP",
+   "Glob": "Wow6432Node\\Microsoft\\Active Setup\\Installed Components\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "AMSI Providers",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://pentestlab.blog/2021/05/17/persistence-amsi/\n",
+   "Comment": "The AMSI provider for Windows Defender seems to have been\nremoved/could not be found.\n\nAnalysis Tip: AMSI providers can be used for persistence.\n\nThe FeatureBit check determines if Authenicode signing is enabled or not.\n  0x01 - signing check is disabled; this is the default behavior (applies if value not found)\n  0x02 - signing check is enabled\n",
+   "Glob": "Microsoft\\AMSI\\Providers\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(\n  FeatureBits=GetValue(OSPath=OSPath + \"FeatureBits\"),\n  ProviderDll=GetProviderDllForGUID(GUID=OSPath.Basename))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Adobe app cRecentFiles values",
+   "Category": "Third Party Applications",
+   "Glob": "*\\Software\\Adobe\\*\\*\\AVGeneral\\cRecentFiles\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') +\n   dict(Version=OSPath[-4], Software=OSPath[-5],\n        sDI=CharsToString(X=GetValue(OSPath=OSPath + \"sDI\")),\n        sDate=CharsToString(X=GetValue(OSPath=OSPath + \"sDate\")))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Adobe app cRecentFiles values",
+   "Category": "Third Party Applications",
+   "Glob": "*\\Software\\Adobe\\*\\*\\AVGeneral\\cRecentFolders\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.') +\n   dict(Version=OSPath[-4], Software=OSPath[-5],\n        sDI=CharsToString(X=GetValue(OSPath=OSPath + \"sDI\")),\n        sDate=CharsToString(X=GetValue(OSPath=OSPath + \"sDate\")))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\MoSetup\\AllowUpgradesWithUnsupportedTPMOrCPU",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\LabConfig\\AllowUpgradesWithUnsupportedTPMOrCPU",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\MoSetup\\BypassRAMCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\LabConfig\\BypassRAMCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\MoSetup\\BypassTPMCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\LabConfig\\BypassTPMCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\MoSetup\\BypassSecureBootCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Check for Windows 11 requirement bypass values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://support.microsoft.com/en-us/windows/ways-to-install-windows-11-e0edbbfb-cfc5-4011-868b-2ce77ac7c70e",
+   "Comment": "Analysis Tip: The \"AllowUpgradesWithUnsupportedTPMOrCPU\" value set\nto 1 is a hack to allow Windows 11 updates to be installed on\nsystems that did not meet the TPM or CPU checks. This could be\ninterpreted as an attempt at defense evasion, by upgrading the\nsystem image to provide additional capabilities, such as Windows\nSubsystem for Android.\n",
+   "Glob": "Setup\\LabConfig\\BypassSecureBootCheck",
+   "Root": "HKEY_LOCAL_MACHINE\\System"
+  },
+  {
+   "Description": "Gets user's AMSIEnable value",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/amsienable.pl",
+   "Comment": "Analysis Tip: If the AmsiEnable value is 0, AMSI is disabled.\n",
+   "Glob": "*\\Software\\Microsoft\\Windows Script\\Settings\\AmsiEnable",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "Gets contents of user's ApplicationAssociationToasts key",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appassoc.pl",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\ApplicationAssociationToasts",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Get entries from AppCertDlls key",
+   "Category": "ASEP",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appcertdlls.pl",
+   "Glob": "ControlSet*\\Control\\Session Manager\\AppCertDlls",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Check services for AppEnvironment/AppEnvironmentExtra values",
+   "Category": "Third Party Applications",
+   "Author": "M. Cohen",
+   "Comment": "Analysis Tip: The AppEnvironment and AppEnvironmentExtra values\nallow a service to have access to environment variables that\noverride those set by the system at service startup. These values\nare used by svrany\\.exe and nssm\\.exe.  Nssm\\.exe makes use of the\nParameters\\\\AppExit subkey to determine actions to take upon exit,\nand can be used to specify specific actions based on the app's\nexit code.\n\nRef: https://nssm.cc/usage\n",
+   "Glob": "ControlSet*\\Services\\*\\Parameters\\AppEnvironment",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Check services for AppEnvironment/AppEnvironmentExtra values",
+   "Category": "Third Party Applications",
+   "Author": "M. Cohen",
+   "Comment": "Analysis Tip: The AppEnvironment and AppEnvironmentExtra values\nallow a service to have access to environment variables that\noverride those set by the system at service startup. These values\nare used by svrany\\.exe and nssm\\.exe.  Nssm\\.exe makes use of the\nParameters\\\\AppExit subkey to determine actions to take upon exit,\nand can be used to specify specific actions based on the app's\nexit code.\n\nRef: https://nssm.cc/usage\n",
+   "Glob": "ControlSet*\\Services\\*\\Parameters\\AppEnvironmentExtra",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets contents of AppInit_DLLs value",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_DLLs",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets contents of AppInit_DLLs value",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\LoadAppInit_DLLs",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets contents of AppInit_DLLs value",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appinitdlls.pl",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Windows\\RequireSignedAppInit_DLLs",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Extracts AppKeys entries",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appkeys.pl",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AppKey",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eAppKeyExtract(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Extracts AppKeys entries",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appkeys.pl",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Explorer\\AppKey",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eAppKeyExtract(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets contents of user's Applets key",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Regedit=dict(\n  LastKey=GetValue(OSPath=x.OSPath + \"Regedit/LastKey\"),\n  Favorites=FetchKeyValuesWithRegex(\n    OSPath=x.OSPath + \"Regedit/Favorites\", Regex='.')))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets AppModelUnlock values",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appmodel.pl",
+   "Comment": "Analysis Tip: Misuse of MS Apps can be an infection vector (see\nref).  AllowAllTrustedApps = 1 allows loading of Apps not from the\nWindows Store (must have valid cert chain) (Enables sideloading)\n\nAllowDevelopmentWithoutDevLicense = 1 enables dev mode, allowing\ninstall of Apps from IDE, and allows users without\nSeCreateSymbolicLinkPrivilege to create symlinks.\n\nRef: https://www.sentinelone.com/labs/inside-malicious-windows-apps-for-malware-deployment/\nRef: https://twitter.com/0gtweet/status/1675583251161792512\n",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath,\n   Regex='AllowAllTrustedApps|AllowDevelopmentWithoutDevLicense')\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Gets content of App Paths subkeys",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/apppaths.pl",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eGetAppPaths(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003etrue",
+   "Preamble": [
+    "LET GetAppPaths(OSPath) = SELECT OSPath, Mtime, FetchKeyValues(OSPath=OSPath) AS App\n  FROM glob(root=OSPath, globs=\"*\", accessor=\"registry\")\n  WHERE IsDir\n"
+   ]
+  },
+  {
+   "Description": "Gets content of App Paths subkeys",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/apppaths.pl",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\App Paths",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eGetAppPaths(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003etrue",
+   "Preamble": [
+    "LET GetAppPaths(OSPath) = SELECT OSPath, Mtime, FetchKeyValues(OSPath=OSPath) AS App\n  FROM glob(root=OSPath, globs=\"*\", accessor=\"registry\")\n  WHERE IsDir\n"
+   ]
+  },
+  {
+   "Description": "Get autolaunch entries for when user connects to Terminal Server",
+   "Category": "Persistence",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appsetup.pl",
+   "Comment": "Analysis Tip: The commands listed will be launched when the user\nconnects to a Terminal Server. The entries will be found in the\nsystem32 folder.\n",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\WinLogon\\AppSetup",
+   "Root": "HKEY_LOCAL_MACHINE\\Software"
+  },
+  {
+   "Description": "Gets contents of user's Intellipoint\\\\AppSpecific subkeys",
+   "Category": "System Info",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appspecific.pl",
+   "Glob": "*\\Software\\Microsoft\\IntelliPoint\\AppSpecific\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n"
+  },
+  {
+   "Description": "Checks for persistence via Universal Windows Platform Apps",
+   "Category": "Persistence",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appx.pl\nhttps://oddvar.moe/2018/09/06/persistence-using-universal-windows-platform-apps-appx/\n",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\PackagedAppXDebug\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=OSPath, Regex='.')\n"
+  },
+  {
+   "Description": "Checks for persistence via Universal Windows Platform Apps",
+   "Category": "Persistence",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/appx.pl\nhttps://oddvar.moe/2018/09/06/persistence-using-universal-windows-platform-apps-appx/\n",
+   "Glob": "*\\Software\\Classes\\ActivatableClasses\\Package\\*\\DebugInformation\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Application=x.OSPath[-1],\n        DebugPath=GetValue(OSPath=OSPath + \"DebugPath\"))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Get shell open command settings for various file types",
+   "Category": "Persistence",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/assoc.pl\nhttps://cocomelonc.github.io/malware/2022/08/26/malware-pers-9.html\n",
+   "Comment": "Malware can persist by taking over the default actions when a user\ndouble-clicks a particular file type.\n",
+   "Glob": "Classes\\*\\shell\\open\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(Application=x.OSPath[3],\n        Key=OSPath,\n        Command=GetValue(OSPath=OSPath))\n"
+  },
+  {
+   "Description": "Get shell open command settings for various file types",
+   "Category": "Persistence",
+   "Author": "M. Cohen",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/assoc.pl\nhttps://cocomelonc.github.io/malware/2022/08/26/malware-pers-9.html\n",
+   "Comment": "Malware can persist by taking over the default actions when a user\ndouble-clicks a particular file type.\n",
+   "Glob": "Classes\\*\\shell\\edit\\command\\@",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(Application=x.OSPath[3],\n        Key=OSPath,\n        Command=GetValue(OSPath=OSPath))\n"
+  },
+  {
+   "Description": "Automount settings",
+   "Category": "System Info",
+   "Reference": "https://github.com/keydet89/RegRipper4.0/blob/main/plugins/automount.pl\n",
+   "Glob": "ControlSet*\\Services\\mountmgr",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003edict(\n    NoAutoMount=GetValue(OSPath=x.OSPath + \"NoAutoMount\"),\n    Automount=if(condition=GetValue(OSPath=x.OSPath + \"NoAutoMount\"),\n      then=\"Disabled\", else=\"Enabled\"))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "Interface Properties (IPv4)",
+   "Category": "System Info",
+   "Glob": "CurrentControl*\\Services\\Tcpip\\Parameters\\Interfaces\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AddressType|DhcpConnForceBroadcastFlag|DhcpDefaultGateway|DhcpDomain|DhcpDomainSearchList|DhcpGatewayHardware|DhcpGatewayHardwareCount|DhcpIPAddress|DhcpNameServer|DhcpServer|DhcpSubnetMask|DhcpSubnetMaskOpt|Domain|EnableDHCP|EnableMulticast|IPAddress|IsServerNapAware|Lease}LeaseObtainedTime|LeaseTerminatesTime|NameServer|RegisterAdapterName|RegistrationEnabled|SubnetMask|T1|T2\") + dict(\n   LeaseObtainedTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseObtainedTime\")),\n   LeaseTerminatesTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseTerminatesTime\")),\n   DhcpGatewayHardware=FormatMAC(x=GetValue(OSPath=x.OSPath + \"DhcpGatewayHardware\") || \"\"),\n   T1=timestamp(epoch=GetValue(OSPath=x.OSPath + \"T1\")),\n   T2=timestamp(epoch=GetValue(OSPath=x.OSPath + \"T2\"))\n)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Interface Properties (IPv6)",
+   "Category": "System Info",
+   "Glob": "CurrentControl*\\Services\\Tcpip6\\Parameters\\Interfaces\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AddressType|DhcpConnForceBroadcastFlag|DhcpDefaultGateway|DhcpDomain|DhcpDomainSearchList|DhcpGatewayHardware|DhcpGatewayHardwareCount|DhcpIPAddress|DhcpNameServer|DhcpServer|DhcpSubnetMask|DhcpSubnetMaskOpt|Domain|EnableDHCP|EnableMulticast|IPAddress|IsServerNapAware|Lease}LeaseObtainedTime|LeaseTerminatesTime|NameServer|RegisterAdapterName|RegistrationEnabled|SubnetMask|T1|T2\") + dict(\n   LeaseObtainedTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseObtainedTime\")),\n   LeaseTerminatesTime=timestamp(epoch=GetValue(OSPath=x.OSPath + \"LeaseTerminatesTime\"))\n)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Regedit.exe Last Run",
+   "Category": "Executables",
+   "Author": "Troyla",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003ex.Mtime"
+  },
+  {
+   "Description": "Regedit.exe Last Key Viewed",
+   "Category": "Executables",
+   "Author": "Troyla",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit\\LastKey",
+   "Root": "HKEY_USERS"
+  },
+  {
+   "Description": "WinLogon: Displays the details of the last user logged in to this system",
+   "Category": "System Info",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\WinLogon",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"AutoLogonSID|LastUsedUsername|AutoAdminLogon|DefaultUserName|DefaultPassword\") + dict(AllValues=FetchKeyValues(OSPath=x.OSPath))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "LogonUI: Displays the last logged on SAM user",
+   "Category": "System Info",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Authentication\\LogonUI",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"LastLoggedOnUser|LastLoggedOnSAMUser|LastLoggedOnDisplayName|SelectedUserSID|LastLoggedOnUserSID\") + dict(AllValues=FetchKeyValues(OSPath=x.OSPath))\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "System Info (Current)",
+   "Category": "System Info",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"SystemRoot|RegisteredOwner|RegisteredOrganization|DisplayVersion|ComputerName|ProductName|InstallDate|InstallationType|CurrentMajorVersionNumber|EditionID|CurrentBuildNumber|CurrentBuild|CompositionEditionID|BuildLab\")\n",
+   "Filter": "x=\u003etrue"
+  },
+  {
+   "Description": "System Info (Historical)",
+   "Category": "System Info",
+   "Glob": "Setup\\Source OS*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValuesWithRegex(OSPath=x.OSPath, Regex=\"SystemRoot|RegisteredOwner|RegisteredOrganization|DisplayVersion|ComputerName|ProductName|InstallDate|InstallationType|CurrentMajorVersionNumber|EditionID|CurrentBuildNumber|CurrentBuild|CompositionEditionID|BuildLab\")\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Firewall Rules",
+   "Category": "System Info",
+   "Glob": "ControlSet001\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\FirewallRules\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eParseFirewallRule(X=x.Data) + dict(RuleName=x.OSPath.Basename)\n",
+   "Preamble": [
+    "LET _ParseFirewallRule(X) = to_dict(item={\n   SELECT split(string=_value, sep_string=\"=\")[0] AS _key,\n          split(string=_value, sep_string=\"=\")[1] AS _value\n   FROM foreach(row=split(string=X, sep_string='|'))\n   WHERE NOT _key =~ \"^v\"\n})\n\nLET MaybeEnrichFirewallRule(OSPath, Details) = if(condition=Details.App,\nthen=Details + GetDetails(OSPath=ExpandPath(Path=Details.App)), else=Details)\n\nLET ParseFirewallRule(X) = MaybeEnrichFirewallRule(\n   OSPath=OSPath, Details=_ParseFirewallRule(X=X)) +\n   dict(Protocol=ProtocolLookup(X=_ParseFirewallRule(X=X).Protocol))\n"
+   ]
+  },
+  {
+   "Description": "Microphone",
+   "Category": "Devices",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(\n  LastUsedTimeStart=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStart\")),\n  LastUsedTimeStop=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStop\"))\n)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Webcam",
+   "Category": "Devices",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\webcam\\**",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(\n  LastUsedTimeStart=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStart\")),\n  LastUsedTimeStop=FILETIME(t=GetValue(OSPath=x.OSPath + \"LastUsedTimeStop\"))\n)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "JumplistData: Displays last execution time of a program",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Search\\JumplistData\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Program=x.OSPath.Basename, LastExecutionTime=FILETIME(t=x.Data))\n"
+  },
+  {
+   "Description": "RunMRU: Tracks commands from the Run box in the Start menu, lower MRU # (Value Data3) = more recent",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRU(OSPath=x.OSPath).value,\n        All=FetchKeyValues(OSPath=x.OSPath))\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "CIDSizeMRU",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\CIDSizeMRU",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET MRUProfile \u003c= '''\n[[\"Header\", 0, [\n   [\"Array\", 0, \"Array\", {\n      \"count\": 500,\n      \"sentinel\": \"x=\u003eNOT x\",\n      \"type\": \"int32\"\n    }]\n]]]\n'''\n\nLET CalculateMRUEx(OSPath) = SELECT split(string=utf16(string=GetValue(OSPath=OSPath + str(str=_value))), sep='\\x00')[0] AS value\nFROM foreach(row=parse_binary(\n       profile=MRUProfile,\n       accessor=\"data\",\n       filename=GetValue(OSPath=OSPath + \"MRUListEx\") || \"\",\n       struct=\"Header\").Array)\nWHERE _value \u003e 0\n"
+   ]
+  },
+  {
+   "Description": "Background Activity Moderator (BAM)",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun",
+   "Glob": "ControlSet*\\Services\\BAM\\State\\UserSettings\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003edict(Programs=_BAMPrograms(Root=x.OSPath),\n        UserSID=x.OSPath.Basename,\n        Username=ResolveSID(SID=x.OSPath.Basename))\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET _BAMPrograms(Root) = SELECT OSPath.Basename AS Program,\n  timestamp(winfiletime=parse_binary(accessor=\"data\",\n      filename=Data.value, struct=\"uint64\")) AS Timestamp\nFROM glob(accessor=\"registry\", globs=\"*\", root=Root)\nWHERE NOT Program =~ \"^(Version|Sequence)\"\n"
+   ]
+  },
+  {
+   "Description": "Desktop Activity Moderator (DAM)",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "ControlSet*\\Services\\DAM\\State\\UserSettings\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003edict(Programs=_BAMPrograms(Root=x.OSPath),\n        UserSID=x.OSPath.Basename,\n        Username=ResolveSID(SID=x.OSPath.Basename))\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "UserAssist: GUI-based programs launched from the desktop",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\*\\Count\\*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Program=rot13(string=x.OSPath.Basename),\n        NumberOfExecutions=_ExtractUserAssist(OSPath=x.Data).NumberOfExecutions,\n        LastExecutionTime=_ExtractUserAssist(OSPath=x.Data).LastExecution)\n",
+   "Preamble": [
+    "LET userAssistProfile = '''\n  [\n    [\"Header\", 0, [\n      [\"NumberOfExecutions\", 4, \"uint32\"],\n      [\"LastExecution\", 60, \"WinFileTime\", {\"type\":\"uint64\"}]\n    ]]\n  ]\n'''\n\nLET _ExtractUserAssist(Data) = parse_binary(accessor=\"data\",\n                  filename=Data,\n                  profile=userAssistProfile, struct=\"Header\")\n"
+   ]
+  },
+  {
+   "Description": "RADAR: Displays applications that were running at one point in time on this system",
+   "Category": "Program Execution",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "Microsoft\\RADAR\\HeapLeakDetection\\DiagnosedApplications",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(Programs=_RADAR(OSPath=x.OSPath))\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET _RADAR(OSPath) = SELECT OSPath.Basename AS Program,\n   timestamp(winfiletime=GetValue(OSPath=OSPath + \"LastDetectionTime\")) AS LastDetectionTime\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"
+   ]
+  },
+  {
+   "Description": "WordWheelQuery: User Searches",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\WordWheelQuery",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "OpenSavePidlMRU: Tracks files that have been opened or saved within a Windows shell dialog box",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\OpenSavePidlMRU",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "OpenSaveMRU: Tracks files that have been opened or saved within a Windows shell dialog box",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\OpenSaveMRU",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "LastVisitedPidlMRU: Tracks the specific executable used by an application to open the files documented in OpenSavePidlMRU",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\ComDlg32\\LastVisitedPidlMRU",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "RecentDocs: Files recently opened from Windows Explorer",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RecentDocs",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(MRU=CalculateMRUEx(OSPath=x.OSPath).value)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Recent File List: Displays recent files accessed by the user with an application",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\*\\*\\Recent File List",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET _RecentFileList(OSPath) = SELECT Data.value AS F\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\nWHERE OSPath.Basename =~ \"File\"\n"
+   ]
+  },
+  {
+   "Description": "Recent Folder List: Displays recent folders accessed by the user with an application",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\*\\*\\Recent Folder List",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Recent Document List: Displays recent Documents accessed by the user with an application",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\*\\*\\Settings\\Recent Document List",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Recent",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\*\\*\\Recent",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "RecentFind",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\*\\*\\RecentFind",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(Files=_RecentFileList(OSPath=x.OSPath).F)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "User Shell Folders: Displays where a user's Shell folders are mapped to",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "FeatureUsage: Displays the number of times the user has received a notification for an application",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FeatureUsage",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(AppBadgeUpdated= _FeatureUsage(OSPath=x.OSPath + \"AppBadgeUpdated\"),\n        AppLaunch=_FeatureUsage(OSPath=x.OSPath + \"AppLaunch\"),\n        AppSwitched=_FeatureUsage(OSPath=x.OSPath + \"AppSwitched\"),\n        ShowJumpView=_FeatureUsage(OSPath=x.OSPath + \"ShowJumpView\"),\n        TrayButtonClicked=FetchKeyValues(OSPath=x.OSPath + \"TrayButtonClicked\"))\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET _FeatureUsage(OSPath) = SELECT OSPath.Basename AS Application,\n    Data.value AS Number\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"
+   ]
+  },
+  {
+   "Description": "Terminal Server Client (RDP): Displays the IP addresses/hostnames of devices this system has connected to (Outbound RDP)",
+   "Category": "User Activity",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Terminal Server Client",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003edict(\n DefaultMRU=RDPMRU(OSPath=OSPath).Server,\n Servers={\n  SELECT OSPath.Basename AS Server, Mtime,\n    FetchKeyValues(OSPath=OSPath) AS Details\n  FROM glob(accessor=\"registry\", globs='*', root=OSPath + \"Servers\")\n})\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET RDPMRU(OSPath) = SELECT Data.value AS Server\nFROM glob(accessor=\"registry\", globs='*', root=OSPath + \"Default\")\nWHERE OSPath.Basename =~ \"MRU\"\n"
+   ]
+  },
+  {
+   "Description": "Run (Group Policy)",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003eIsDir AND Details"
+  },
+  {
+   "Description": "Run (NTUSER)",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run*",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003eIsDir AND Details"
+  },
+  {
+   "Description": "Run (SYSTEM)",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "Microsoft\\Windows\\CurrentVersion\\Run*",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003eEnumerateRunKey(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003eIsDir AND Details",
+   "Preamble": [
+    "LET EnumerateRunKey(OSPath) = SELECT Name, Data.value AS RawTarget, ExpandPath(Path=Data.value) AS CommandImage, GetDetails(OSPath=ExpandPath(Path=Data.value)) AS Details FROM glob(accessor=\"registry\", globs=\"*\", root=OSPath) WHERE NOT IsDir"
+   ]
+  },
+  {
+   "Description": "Scheduled Tasks (TaskCache)",
+   "Category": "Autoruns",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(Tasks= _TaskCache(OSPath=x.OSPath))\n",
+   "Filter": "x=\u003eIsDir AND Details",
+   "Preamble": [
+    "LET _ParseActions(Data)  = parse_binary(accessor=\"data\",\n            filename=Data, struct=\"Header\",\n            profile='''\n[[\"Header\", 0, [\n [\"__Ver\", 0, \"uint16\"],\n [\"__UserLen\", 2, \"uint32\"],\n [\"User\", 6, \"String\", {length: \"x=\u003ex.__UserLen\", encoding: \"utf16\"}],\n [\"__ActionType\", \"x=\u003e6 + x.__UserLen\", \"uint16\"],\n [\"ActionType\", \"x=\u003e6 + x.__UserLen\", \"Enumeration\", {\n    type: \"uint32\",\n    choices: {\n      \"26214\": \"BinaryAction\",\n      \"30583\": \"ComHanlder\",\n      \"34952\": \"Email\",\n      \"39321\": \"MessageBox\",\n    }\n }],\n [\"Action\", \"x=\u003e6 + x.__UserLen + 2\", \"Union\", {\n   selector: \"x=\u003ex.__ActionType\",\n   choices: {\n     \"26214\": BinaryAction,\n     \"30583\": ComHandler,\n   }\n }],\n]],\n[\"ComHandler\", 0, [\n [\"ClassID\", 4, \"GUID\"],\n [\"__DataLen\", 20, uint32],\n [\"Data\", 24, \"String\", {\n   \"length\": \"x=\u003ex.__DataLen\",\n   \"encoding\": \"utf16\",\n }]\n]],\n[\"GUID\", 16, [\n [\"__D1\", 0, \"uint32\"],\n [\"__D2\", 4, \"uint16\"],\n [\"__D3\", 6, \"uint16\"],\n [\"__D4\", 8, \"String\", {\"term\": \"\", \"length\": 2}],\n [\"__D5\", 10, \"String\", {\"term\": \"\", \"length\": 6}],\n [\"Value\", 0, \"Value\", {\n    \"value\": \"x=\u003eformat(format='{%08x-%04x-%04x-%02x-%02x}', args=[x.__D1, x.__D2, x.__D3, x.__D4, x.__D5])\"\n}]\n]],\n[\"BinaryAction\", 0, [\n [\"__BinLen\", 4, \"uint32\"],\n [\"Binary\", 8, \"String\", {length: \"x=\u003ex.__BinLen\", encoding: \"utf16\"}],\n]]]\n''')\n\nLET _ParseDynamicInfo(Data) = parse_binary(accessor=\"data\",\n            filename=Data, struct=\"Header\",\n            profile='''\n[[\"Header\", 0, [\n [\"__Ver\", 0, \"uint16\"],\n [\"Created\", 4, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"LastStart\", 12, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"LastStop\", 20, \"WinFileTime\", {\"type\": \"uint64\"}],\n [\"TaskState\", 28, \"uint32\"],\n [\"LastErrorCode\", 32, \"uint32\"],\n [\"LastSuccessfulRun\", 36, \"WinFileTime\", {\"type\": \"uint64\"}],\n]]]\n''')\n\nLET _TaskCache(OSPath) = SELECT to_dict(item={\n  SELECT OSPath.Basename AS _key,\n    if(condition= OSPath.Basename =~ \"DynamicInfo\",\n       then=_ParseDynamicInfo(Data=Data.value),\n    else= if(condition= OSPath.Basename =~ \"Actions\",\n       then=_ParseActions(Data=Data.value),\n    else=Data.value)) AS _value\n  FROM glob(accessor=\"registry\", globs='*', root=OSPath)\n}) + dict(OSPath=OSPath) AS Details\nFROM glob(accessor=\"registry\", globs='*', root=OSPath)\n"
+   ]
+  },
+  {
+   "Description": "Services: Displays list of services running on this computer",
+   "Category": "Services",
+   "Author": "Andrew Rathbun, Mike Cohen",
+   "Glob": "ControlSet*\\Services\\*",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003e_ServicesInfo(OSPath=x.OSPath)\n",
+   "Filter": "x=\u003eIsDir",
+   "Preamble": [
+    "LET _ServiceTypeLookup \u003c= dict(`1`=\"KernelDriver\", `2`=\"FileSystemDriver\", `4`=\"Adapter\", `8`=\"RecognizerDriver\", `16`=\"Win32OwnProcess\", `32`=\"Win32ShareProcess\", `256`=\"InteractiveProcess\", `96`=\"Win32ShareProcess\")\nLET _ServiceStartModeLookup \u003c= dict(`0`=\"Boot\", `1`=\"System\", `2`=\"Automatic\", `3`=\"Manual\", `4`=\"Disabled\")\n\nLET MaybeEnrichService(OSPath, Details) = if(condition=Details.ImagePath,\n then=Details + GetDetails(OSPath=ExpandPath(Path=Details.ImagePath)),\n else=Details)\n\nLET _ServicesInfo(OSPath) = MaybeEnrichService(OSPath=OSPath, Details=\n    FetchKeyValuesWithRegex(OSPath=OSPath,\n         Regex=\"Description|DisplayName|ServiceDll|Group|ImagePath|RequiredPrivileges|Type|Parameters|SERVICEDLL\") +\n    dict(Mtime=Mtime, Service=OSPath.Basename,\n         TypeName=get(item=_ServiceTypeLookup, field=str(str=GetValue(OSPath=OSPath + \"Type\"))),\n         StartName=get(item=_ServiceStartModeLookup, field=str(str=GetValue(OSPath=OSPath + \"Start\")))\n    ))\n"
+   ]
+  },
+  {
+   "Description": "Environment Variables",
+   "Category": "System Info",
+   "Glob": "ControlSet*\\Control\\Session Manager\\Environment",
+   "Root": "HKEY_LOCAL_MACHINE\\System",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Environment Variables",
+   "Category": "System Info",
+   "Glob": "*\\Environment",
+   "Root": "HKEY_USERS",
+   "Details": "x=\u003eFetchKeyValues(OSPath=x.OSPath)",
+   "Filter": "x=\u003eIsDir"
+  },
+  {
+   "Description": "Exploit Guards MitigationOptions",
+   "Category": "System Info",
+   "Author": "@bmcdermott-r7 Blake McDermott",
+   "Reference": "https://theryuu.github.io/ifeo-mitigationoptions.txt\n",
+   "Comment": "Parses Exploit Guards MitigationOptions to see what security\ncontrols are enabled for each process, and returns them in a 15\ndigit hexidecimal value.\n",
+   "Glob": "Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\MitigationOptions",
+   "Root": "HKEY_LOCAL_MACHINE\\Software",
+   "Details": "x=\u003edict(ProcName=x.OSPath[-2],\n        DecValue=x.Data,\n        HexValue=format(format=\"%#015x\", args=x.Data),\n        Parsed=ParseMitigationOptions(H=format(format=\"%#015x\", args=x.Data)))\n",
+   "Preamble": [
+    "LET ParseMitigationOptions(H) = RemoveNullDictValue(D=dict(\n DEP=\n   (H[-1:] = \"1\" \u0026\u0026 \"Always On\") ||\n   (H[-1:] = \"2\" \u0026\u0026 \"Always On - enable ATL thunk emulation\"),\n SEHOP=(H[-2:-1] = \"1\"),\n ASLR=\n    (H[-3:-2] = \"1\" \u0026\u0026 \"Enable force relocate.\") ||\n    (H[-3:-2] = \"2\" \u0026\u0026 \"Force relocate off.\") ||\n    (H[-3:-2] = \"3\" \u0026\u0026 \"Force relocate always on.\"),\n `Heap terminate`=\n    (H[-4:-3] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-4:-3] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Bottom ASLR`=\n    (H[-5:-4] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-5:-4] = \"2\" \u0026\u0026 \"Always Off.\"),\n `HEASLR`=\n    (H[-6:-5] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-6:-5] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Strict handle checks`=\n    (H[-7:-6] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-7:-6] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Win32k system call disable policy`=\n    (H[-8:-7] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-8:-7] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Extension point disable policy`=\n    (H[-9:-8] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-9:-8] = \"2\" \u0026\u0026 \"Always Off.\"),\n `Dynamic code policy (probably).`=\n    (H[-10:-9] = \"1\" \u0026\u0026 \"Always On.\") ||\n    (H[-10:-9] = \"2\" \u0026\u0026 \"Always Off.\") ||\n    (H[-10:-9] = \"3\" \u0026\u0026 \"Always On with optout.\"),\n `Control Flow Guard (CFG)`=\n    (H[-11:-10] = \"1\" \u0026\u0026 \"Enable\") ||\n    (H[-11:-10] = \"2\" \u0026\u0026 \"Disable\"),\n `Binary signature policy.`=\n    (H[-12:-11] = \"1\" \u0026\u0026 \"Microsoft signed only.\") ||\n    (H[-12:-11] = \"2\" \u0026\u0026 \"Disable?\"),\n `Font loading prevention.`=\n    (H[-13:-12] = \"1\" \u0026\u0026 \"Enable\") ||\n    (H[-13:-12] = \"2\" \u0026\u0026 \"Disable\") ||\n    (H[-13:-12] = \"3\" \u0026\u0026 \"Enable with Audit\"),\n `Image load policy (remote images).`=\n    (H[-14:-13] = \"1\" \u0026\u0026 \"Always On\") ||\n    (H[-14:-13] = \"2\" \u0026\u0026 \"Always Off\") ||\n    (H[-14:-13] = \"3\" \u0026\u0026 \"Reserved\"),\n `Image load policy (low mandatory label).`=\n    (H[-15:-14] = \"1\" \u0026\u0026 \"Always On\") ||\n    (H[-15:-14] = \"2\" \u0026\u0026 \"Always Off\") ||\n    (H[-15:-14] = \"3\" \u0026\u0026 \"Reserved\")))\n"
+   ]
+  }
+ ]

--- a/tests/artifact_test.go
+++ b/tests/artifact_test.go
@@ -157,11 +157,11 @@ func (self *RegistryHunterTestSuite) SetupTest() {
 }
 
 type testCase struct {
-	Name              string
-	Artifact          string
-	DescriptionFilter string
-	Root              string
-	Columns           []string
+	Name       string
+	Artifact   string
+	RuleFilter string
+	Root       string
+	Columns    []string
 
 	Disable bool
 }
@@ -175,124 +175,124 @@ var (
 		// Cover off on all the different hives we are supposed to map
 		{
 			// Covers HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services
-			Name:              "Interface Properties",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Interface Properties",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Interface Properties",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Interface Properties",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_LOCAL_MACHINE\Software
-			Name:              "WinLogon",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "WinLogon: Displays the details of the last user",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "WinLogon",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "WinLogon: Displays the details of the last user",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_LOCAL_MACHINE\System
-			Name:              "System Info",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "System Info",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "System Info",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "System Info",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_LOCAL_MACHINE\System
-			Name:              "Firewall Rules",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Firewall Rules",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Firewall Rules",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Firewall Rules",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_USERS
-			Name:              "Regedit.exe",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Regedit.exe",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Regedit.exe",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Regedit.exe",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_USERS
-			Name:              "MRU",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "MRU",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "MRU",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "MRU",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_USERS
-			Name:              "UserAssist",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "UserAssist",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "UserAssist",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "UserAssist",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_USERS
-			Name:              "WordWheelQuery",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "WordWheelQuery",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "WordWheelQuery",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "WordWheelQuery",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
 			// Covers HKEY_LOCAL_MACHINE\System
-			Name:              "Background Activity Moderator",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Background Activity Moderator",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Background Activity Moderator",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Background Activity Moderator",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "UserAssist",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "UserAssist",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "UserAssist",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "UserAssist",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "Recent File List",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Recent File List",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Recent File List",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Recent File List",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "User Shell Folders",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "User Shell Folders",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "User Shell Folders",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "User Shell Folders",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "RDP",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "RDP",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "RDP",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "RDP",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "Scheduled Tasks",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Scheduled Tasks",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Scheduled Tasks",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Scheduled Tasks",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "Services",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Services",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Services",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Services",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 		{
-			Name:              "Environment",
-			Artifact:          "Windows.Registry.Hunter/Results",
-			DescriptionFilter: "Environment",
-			Root:              reghiveTestDirectory,
-			Columns:           standardColumns,
+			Name:       "Environment",
+			Artifact:   "Windows.Registry.Hunter/Results",
+			RuleFilter: "Environment",
+			Root:       reghiveTestDirectory,
+			Columns:    standardColumns,
 		},
 	}
 )
@@ -319,11 +319,11 @@ func (self *RegistryHunterTestSuite) TestArtifact() {
 		RootDrive, _ := filepath.Abs(test.Root)
 		cmdline := []string{
 			self.binary, "--logfile", log_file.Name(),
-			"--definitions", artifactPath,
+			"--definitions", artifactPath, "--debug", "--debug_port", "6061",
 			"artifacts", "collect", test.Artifact, "--format", "jsonl",
 			"--args", "RootDrive=" + RootDrive,
 			"--args", `RemappingStrategy=Raw Hives`,
-			"--args", "DescriptionFilter=" + test.DescriptionFilter,
+			"--args", "RuleFilter=" + test.RuleFilter,
 		}
 		fmt.Printf("Testing %v\nRunning command %v\n", test.Name, cmdline)
 


### PR DESCRIPTION
Many rules uncover traces in the registry to other files on the system. This change allows the other files to be collected or hashed.

Current rules implementing adaptive target resolution are:
* Firewall Rules
* Run (SYSTEM)
* Services: Displays list of services running on this computer

More rules to come.